### PR TITLE
Fix MOTD coloring

### DIFF
--- a/src/main/java/tc/oc/pgm/listeners/MotdListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/MotdListener.java
@@ -71,6 +71,6 @@ public class MotdListener implements Listener {
     }
     MOTD_DATA.put(STATE_NAME_KEY, name);
     MOTD_DATA.put(STATE_NAME_LOWER_KEY, name.toLowerCase());
-    MOTD_DATA.put(STATE_COLOR_KEY, ChatColor.COLOR_CHAR + color.toString());
+    MOTD_DATA.put(STATE_COLOR_KEY, color.toString());
   }
 }


### PR DESCRIPTION
Turns out `toString` contains the section symbol. 