### PR TITLE
Show all errors if map not specified.

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/MapDevelopmentCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MapDevelopmentCommands.java
@@ -63,11 +63,14 @@ public class MapDevelopmentCommands {
       throws CommandException {
     Multimap<PGMMap, PGMMap.MapLogRecord> errors = getErrors();
     Multimap<PGMMap, PGMMap.MapLogRecord> filtered = ArrayListMultimap.create();
-    filtered.putAll(map, errors.get(map));
-    errors = filtered;
+
+    if (map != null) {
+      filtered.putAll(map, errors.get(map));
+      errors = filtered;
+    }
 
     new PrettyPaginatedResult<Entry<PGMMap, MapLogRecord>>(
-        map == null ? "Map Errors" : map.getName() + " Errors") {
+        map == null ? "Errors" : map.getName() + " Errors") {
       @Override
       public String format(Map.Entry<PGMMap, PGMMap.MapLogRecord> entry, int index) {
         return entry.getValue().getLegacyFormattedMessage();


### PR DESCRIPTION
Previously errors would not show if a map was not specified, since it would try to filter errors of map `null`. Now, errors are not filtered and instead all errors are shown if a map is not specified. I did not make it choose a "default" map if one was not specified, because it seems there can be multiple matches. Also, showing all errors seems more intuitive for the command `/errors`. Resolves #7 .

Signed-off-by: ThatOneTqnk <nodeadbatteries@gmail.com>