### PR TITLE
Make wither bossbars less annoying

### DIFF
--- a/src/main/java/tc/oc/bossbar/BossBarView.java
+++ b/src/main/java/tc/oc/bossbar/BossBarView.java
@@ -15,6 +15,7 @@ public class BossBarView implements BossBarObserver {
 
   public static final float BOSS_18_HEALTH = 300;
   public static final double BOSS_18_DISTANCE = 50;
+  public static final float BOSS_18_ANGLE = 20;
   public static final int MAX_TEXT_LENGTH = 64;
 
   private final Plugin plugin;
@@ -72,14 +73,15 @@ public class BossBarView implements BossBarObserver {
   }
 
   private void spawnBoss() {
-    resetBossLocation();
+    resetBossLocation(viewer.getLocation());
     NMSHacks.spawnWither(viewer, entityId, location, renderText(), renderMeter());
     spawned = true;
   }
 
-  private void resetBossLocation() {
-    location = viewer.getLocation();
-    // Keep the boss in the center of the player's view
+  private void resetBossLocation(Location pos) {
+    location = pos;
+    // Keep the boss a few degrees up from the center of the player's view
+    location.setPitch(location.getPitch() - BOSS_18_ANGLE);
     location.add(location.getDirection().multiply(BOSS_18_DISTANCE));
   }
 
@@ -104,7 +106,7 @@ public class BossBarView implements BossBarObserver {
   // Dispatched from elsewhere
   public void onPlayerMove(PlayerMoveEvent event) {
     if (viewer == event.getPlayer() && spawned) {
-      resetBossLocation();
+      resetBossLocation(event.getTo().clone());
       NMSHacks.teleportEntity(viewer, entityId, location);
     }
   }

--- a/src/main/java/tc/oc/pgm/bossbar/BossBarMatchModule.java
+++ b/src/main/java/tc/oc/pgm/bossbar/BossBarMatchModule.java
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInitialSpawnEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import tc.oc.bossbar.BossBar;
 import tc.oc.bossbar.BossBarStack;
 import tc.oc.bossbar.BossBarView;
@@ -85,6 +86,12 @@ public class BossBarMatchModule extends MatchModule implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerMove(PlayerMoveEvent event) {
+    BossBarView view = views.get(event.getPlayer());
+    if (view != null) view.onPlayerMove(event);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPlayerMove(PlayerTeleportEvent event) {
     BossBarView view = views.get(event.getPlayer());
     if (view != null) view.onPlayerMove(event);
   }

--- a/src/main/java/tc/oc/world/NMSHacks.java
+++ b/src/main/java/tc/oc/world/NMSHacks.java
@@ -393,8 +393,8 @@ public interface NMSHacks {
 
   static EntityMetadata createWitherMetadata(String name, float health) {
     EntityMetadata data = createBossMetadata(name, health);
-    DataWatcher watcher = ((EntityMetadata) data).dataWatcher;
-    watcher.a(20, (int) 1000); // Invulnerability countdown
+    DataWatcher watcher = data.dataWatcher;
+    watcher.a(20, 890); // Invulnerability countdown
     return data;
   }
 


### PR DESCRIPTION
Fixes a few of the issues mentioned in #31 , but does not include support for native 1.9+ bossbar API.
- Invul is now 890 (makes wither invisible)
- Wither moved 20 degrees up (makes it not get in your way)
- Teleporting (like when using the compass) also moves the wither away

I did not move the wither closer to the player (32 blocks), wich makes 1.8 clients on 2 chunk render distance see the wither, because 1.14 clients can see the wither particles at that distance.
Moving wither closer should be done only for 1.7/8 clients, when support for native 1.9+ bossbars is added.