### PR TITLE
Fixed Timed Restarts

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -31,7 +31,7 @@ import tc.oc.util.TimeUtils;
 public class AdminCommands {
 
   @Command(
-      aliases = {"restart"},
+      aliases = {"timedrestart"},
       desc = "Queues a server restart after a certain amount of time",
       usage = "[seconds] - defaults to 30 seconds",
       flags = "f",

--- a/src/main/java/tc/oc/pgm/restart/RestartManager.java
+++ b/src/main/java/tc/oc/pgm/restart/RestartManager.java
@@ -98,6 +98,10 @@ public class RestartManager implements Runnable, Listener {
   }
 
   public void requestTimedRestart(Duration duration) {
+    if (queuedRestartTask > 0) {
+      this.plugin.getServer().getScheduler().cancelTask(queuedRestartTask);
+      queuedRestartTask = 0;
+    }
     Instant queueStamp = Instant.now();
     long ticks = duration.getStandardSeconds() * 20;
     queuedRestartTask =

--- a/src/main/java/tc/oc/pgm/restart/RestartManager.java
+++ b/src/main/java/tc/oc/pgm/restart/RestartManager.java
@@ -106,7 +106,10 @@ public class RestartManager implements Runnable, Listener {
             .runTaskLater(
                 this.plugin,
                 () -> {
-                  if (!this.deferrals.isEmpty()) return;
+                  if (!this.deferrals.isEmpty()) {
+                    timedQueuedRestartTaskID = 0;
+                    return;
+                  }
                   timedQueuedRestartTaskID = 0;
                   logger.info("Restarting due to request at " + queueStamp);
                   this.plugin.getServer().shutdown();
@@ -123,8 +126,10 @@ public class RestartManager implements Runnable, Listener {
   }
 
   public void cancelRestart() {
-    if (timedQueuedRestartTaskID > 0)
+    if (timedQueuedRestartTaskID > 0) {
       this.plugin.getServer().getScheduler().cancelTask(timedQueuedRestartTaskID);
+      timedQueuedRestartTaskID = 0;
+    }
     if (this.isRestartRequested()) {
       this.queuedAt = null;
       this.reason = null;

--- a/src/main/java/tc/oc/pgm/util/RestartListener.java
+++ b/src/main/java/tc/oc/pgm/util/RestartListener.java
@@ -167,8 +167,7 @@ public class RestartListener implements Listener {
    * duration.
    */
   public void queueRestart(Match match, Duration duration, String reason) {
-    this.startCountdown(match, duration);
-    RestartManager.get().requestRestart(reason);
+    RestartManager.get().requestTimedRestart(duration);
   }
 
   /**


### PR DESCRIPTION
Uses a delayed task and only does its job if there are no deferrals. Task is cancelled if `RestartManager#cancelRestart` is called. Resolves #9 .

Renames `/restart` to `/timedrestart` (Otherwise, it uses the default `/restart` from Spigot)

Signed-off-by: ThatOneTqnk <nodeadbatteries@gmail.com>