### PR TITLE
Fix NPE in block transform event call

### DIFF
--- a/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java
@@ -91,11 +91,12 @@ public class MatchPlayerStateImpl implements MatchPlayerState, MultiAudience {
 
   @Override
   public String toString() {
+    Location location = getLocation();
     return new ToStringBuilder(this)
         .append("id", getId())
         .append("party", getParty().getDefaultName())
         .append("match", getMatch().getId())
-        .append("location", getLocation().toVector())
+        .append("location", location == null ? null : location.toVector())
         .build();
   }
 }


### PR DESCRIPTION
`getLocation()` is nullable.

https://github.com/Electroid/PGM/blob/358a39778f5176f89ead6f5e5911a2ff08d0c088/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java#L56-L59

https://github.com/Electroid/PGM/blob/358a39778f5176f89ead6f5e5911a2ff08d0c088/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java#L30

Stack trace:

```
[02:27:47 ERROR]: Could not pass event EntityExplodeEvent to PGM v1.8-SNAPSHOT-358a397
org.bukkit.event.EventException
        at tc.oc.pgm.listeners.BlockTransformListener$1.execute(BlockTransformListener.java:95) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:74) ~[sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:65) ~[sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.SimplePluginManager.callEventHandler(SimplePluginManager.java:569) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.SimplePluginManager.dispatchEvent(SimplePluginManager.java:534) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.SimplePluginManager.callEventSynchronously(SimplePluginManager.java:527) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:521) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:496) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.Explosion.a(Explosion.java:201) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.World.createExplosion(World.java:2026) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.WorldServer.createExplosion(WorldServer.java:1059) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.EntityTNTPrimed.explode(EntityTNTPrimed.java:113) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.EntityTNTPrimed.t_(EntityTNTPrimed.java:87) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.World.entityJoinedWorld(World.java:1703) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.World.g(World.java:1670) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.World.tickEntities(World.java:1503) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.WorldServer.tickEntities(WorldServer.java:602) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:948) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:365) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:821) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:722) [sportpaper-1.8.8-R0.1-20191014.013829-10.jar:git-SportPaper-"374af6d"]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_221]
Caused by: java.lang.NullPointerException
        at tc.oc.pgm.match.MatchPlayerStateImpl.toString(MatchPlayerStateImpl.java:98) ~[?:?]
        at java.lang.String.valueOf(Unknown Source) ~[?:1.8.0_221]
        at java.lang.StringBuilder.append(Unknown Source) ~[?:1.8.0_221]
        at tc.oc.pgm.events.PlayerBlockTransformEvent.toString(PlayerBlockTransformEvent.java:66) ~[?:?]
        at java.lang.String.valueOf(Unknown Source) ~[?:1.8.0_221]
        at java.lang.StringBuilder.append(Unknown Source) ~[?:1.8.0_221]
        at tc.oc.pgm.listeners.BlockTransformListener.callEvent(BlockTransformListener.java:144) ~[?:?]
        at tc.oc.pgm.listeners.BlockTransformListener.callEvent(BlockTransformListener.java:166) ~[?:?]
        at tc.oc.pgm.listeners.BlockTransformListener.onEntityExplode(BlockTransformListener.java:295) ~[?:?]
        at sun.reflect.GeneratedMethodAccessor164.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_221]
        at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_221]
        at tc.oc.pgm.listeners.BlockTransformListener$1.execute(BlockTransformListener.java:93) ~[?:?]
        ... 21 more
```