### PR TITLE
Fix compact attribute modifier parsing

### DIFF
--- a/src/main/java/tc/oc/pgm/util/XMLUtils.java
+++ b/src/main/java/tc/oc/pgm/util/XMLUtils.java
@@ -1051,20 +1051,18 @@ public class XMLUtils {
     AttributeModifier.Operation operation = parseAttributeOperation(node, parts[1]);
     double amount = parseNumber(node, parts[2], Double.class);
 
-    return Pair.create(
-        attribute.getName(),
-        null /*Bukkit.getAttributeFactory().newAttributeModifier("FromXML", amount, operation)*/);
+    return Pair.create(attribute.getName(), new AttributeModifier("FromXML", amount, operation));
   }
 
   public static Pair<String, AttributeModifier> parseAttributeModifier(Element el)
       throws InvalidXMLException {
-    return Pair.create(
-        parseAttribute(new Node(el)).getName(),
-        /*Bukkit.getAttributeFactory().newAttributeModifier(
-            "FromXML",
-            parseNumber(Node.fromRequiredAttr(el, "amount"), Double.class),
-            parseAttributeOperation(Node.fromAttr(el, "operation"), AttributeModifier.Operation.ADD)
-        )*/ null);
+    String attribute = parseAttribute(new Node(el)).getName();
+    double amount = parseNumber(Node.fromRequiredAttr(el, "amount"), Double.class);
+    AttributeModifier.Operation operation =
+        parseAttributeOperation(
+            Node.fromAttr(el, "operation"), AttributeModifier.Operation.ADD_NUMBER);
+
+    return Pair.create(attribute, new AttributeModifier("FromXML", amount, operation));
   }
 
   public static GameMode parseGameMode(Node node, String text) throws InvalidXMLException {


### PR DESCRIPTION
Parsing attribute modifiers in XML attributes didn't work.

```java
[20:09:40 INFO]: Vengeance\map.xml: Unhandled java.lang.NullPointerException, caused by: null
[20:09:40 WARN]: java.lang.NullPointerException
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaItem.createAttributeModifierTag(CraftMetaItem.java:550)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaItem.copyAttributeModifiers(CraftMetaItem.java:563)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaItem.applyToItem(CraftMetaItem.java:489)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack.setItemMeta(CraftItemStack.java:407)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack.setItemMeta(CraftItemStack.java:386)
[20:09:40 WARN]:        at tc.oc.pgm.kits.KitParser.parseItem(KitParser.java:390)
[20:09:40 WARN]:        at tc.oc.pgm.kits.KitParser.parseItem(KitParser.java:373)
[20:09:40 WARN]:        at tc.oc.pgm.kits.KitParser.parseItem(KitParser.java:369)
[20:09:40 WARN]:        at tc.oc.pgm.kits.KitParser.parseItemKit(KitParser.java:211)
[20:09:40 WARN]:        at tc.oc.pgm.kits.KitParser.parseDefinition(KitParser.java:108)
[20:09:40 WARN]:        at tc.oc.pgm.kits.LegacyKitParser.parse(LegacyKitParser.java:34)
[20:09:40 WARN]:        at tc.oc.pgm.classes.ClassModule.parseClass(ClassModule.java:165)
[20:09:40 WARN]:        at tc.oc.pgm.classes.ClassModule.parse(ClassModule.java:100)
[20:09:40 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[20:09:40 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[20:09:40 WARN]:        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[20:09:40 WARN]:        at java.lang.reflect.Method.invoke(Unknown Source)
[20:09:40 WARN]:        at tc.oc.pgm.map.StaticMethodMapModuleFactory.parse(StaticMethodMapModuleFactory.java:65)
[20:09:40 WARN]:        at tc.oc.pgm.map.MapModuleContext.loadModule(MapModuleContext.java:101)
[20:09:40 WARN]:        at tc.oc.pgm.map.MapModuleContext.loadModule(MapModuleContext.java:33)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadWithDependencies(ModuleLoader.java:162)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadDependencies(ModuleLoader.java:129)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadWithDependencies(ModuleLoader.java:157)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadDependencies(ModuleLoader.java:117)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadWithDependencies(ModuleLoader.java:157)
[20:09:40 WARN]:        at tc.oc.pgm.module.ModuleLoader.loadAll(ModuleLoader.java:98)
[20:09:40 WARN]:        at tc.oc.pgm.map.MapModuleContext.load(MapModuleContext.java:113)
[20:09:40 WARN]:        at tc.oc.pgm.map.PGMMap.load(PGMMap.java:114)
[20:09:40 WARN]:        at tc.oc.pgm.map.PGMMap.reload(PGMMap.java:152)
[20:09:40 WARN]:        at tc.oc.pgm.map.MapLoader.loadNewMaps(MapLoader.java:74)
[20:09:40 WARN]:        at tc.oc.pgm.map.MapLoader.loadNewMaps(MapLoader.java:46)
[20:09:40 WARN]:        at tc.oc.pgm.match.MatchManagerImpl.loadNewMaps(MatchManagerImpl.java:232)
[20:09:40 WARN]:        at tc.oc.pgm.match.MatchManagerImpl.<init>(MatchManagerImpl.java:48)
[20:09:40 WARN]:        at tc.oc.pgm.PGM.onEnable(PGM.java:192)
[20:09:40 WARN]:        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:320)
[20:09:40 WARN]:        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:332)
[20:09:40 WARN]:        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:409)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.CraftServer.loadPlugin(CraftServer.java:305)
[20:09:40 WARN]:        at org.bukkit.craftbukkit.v1_8_R3.CraftServer.enablePlugins(CraftServer.java:264)
[20:09:40 WARN]:        at net.minecraft.server.v1_8_R3.MinecraftServer.s(MinecraftServer.java:431)
[20:09:40 WARN]:        at net.minecraft.server.v1_8_R3.MinecraftServer.k(MinecraftServer.java:395)
[20:09:40 WARN]:        at net.minecraft.server.v1_8_R3.MinecraftServer.a(MinecraftServer.java:350)
[20:09:40 WARN]:        at net.minecraft.server.v1_8_R3.DedicatedServer.init(DedicatedServer.java:263)
[20:09:40 WARN]:        at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:667)
[20:09:40 WARN]:        at java.lang.Thread.run(Unknown Source)
```