### PR TITLE
Fix single child union region parsing

### DIFF
--- a/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -297,13 +297,10 @@ public abstract class RegionParser {
   @MethodParser("union")
   public Region parseUnion(Element el) throws InvalidXMLException {
     Region[] regions = this.parseSubRegionsArray(el);
-    switch (regions.length) {
-      case 0:
-        return EmptyRegion.INSTANCE;
-      case 1:
-        return regions[0];
-      default:
-        return new Union(regions);
+    if (regions.length < 1) {
+      return EmptyRegion.INSTANCE;
+    } else {
+      return new Union(regions);
     }
   }
 


### PR DESCRIPTION
Return a union containing the child even if only a single child exists.

This process is in line with the parsing of the latest version of `OvercastNetwork/ProjectAres` and would resolve #82. Further details can be found in the discussion of issue of the aforementioned issue.