### PR TITLE
Readd entities in modify bow projectile, and fix enderpearls

### DIFF
--- a/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Entity;
 import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -19,12 +19,12 @@ import tc.oc.xml.InvalidXMLException;
 
 @ModuleDescription(name = "Modify Bow Projectile")
 public class ModifyBowProjectileModule extends MapModule {
-  protected final Class<? extends Projectile> cls;
+  protected final Class<? extends Entity> cls;
   protected final float velocityMod;
   protected final Set<PotionEffect> potionEffects;
 
   public ModifyBowProjectileModule(
-      Class<? extends Projectile> cls, float velocityMod, Set<PotionEffect> effects) {
+      Class<? extends Entity> cls, float velocityMod, Set<PotionEffect> effects) {
     this.cls = cls;
     this.velocityMod = velocityMod;
     potionEffects = effects;
@@ -43,7 +43,7 @@ public class ModifyBowProjectileModule extends MapModule {
   public static ModifyBowProjectileModule parse(
       MapModuleContext context, Logger logger, Document doc) throws InvalidXMLException {
     boolean changed = false;
-    Class<? extends Projectile> projectile = Arrow.class;
+    Class<? extends Entity> projectile = Arrow.class;
     float velocityMod = 1;
     Set<PotionEffect> potionEffects = new HashSet<>();
 
@@ -56,7 +56,7 @@ public class ModifyBowProjectileModule extends MapModule {
 
       Element projectileElement = parent.getChild("projectile");
       if (projectileElement != null) {
-        projectile = XMLUtils.parseProjectileType(projectileElement);
+        projectile = XMLUtils.parseEntityType(projectileElement);
         changed = true;
       }
 

--- a/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -57,7 +57,7 @@ public class ProjectileModule extends MapModule {
               "click action",
               ClickAction.BOTH);
       Class<? extends Entity> entity =
-          XMLUtils.parseProjectileTypeAttribute(projectileElement, "projectile", Arrow.class);
+          XMLUtils.parseEntityTypeAttribute(projectileElement, "projectile", Arrow.class);
       List<PotionEffect> potionKit = kitParser.parsePotions(projectileElement);
       Filter destroyFilter = filterParser.parseFilterProperty(projectileElement, "destroy-filter");
       Duration coolDown = XMLUtils.parseDuration(projectileElement.getAttribute("cooldown"));

--- a/src/main/java/tc/oc/pgm/util/XMLUtils.java
+++ b/src/main/java/tc/oc/pgm/util/XMLUtils.java
@@ -19,7 +19,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.bukkit.*;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Entity;
 import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -498,34 +498,31 @@ public class XMLUtils {
     return node == null ? def : parseSecondDuration(node);
   }
 
-  public static Class<? extends Projectile> parseProjectileType(Element el)
-      throws InvalidXMLException {
-    return parseProjectileType(new Node(el));
+  public static Class<? extends Entity> parseEntityType(Element el) throws InvalidXMLException {
+    return parseEntityType(new Node(el));
   }
 
-  public static Class<? extends Projectile> parseProjectileType(Node node)
-      throws InvalidXMLException {
-    return parseProjectileType(node, node.getValue());
+  public static Class<? extends Entity> parseEntityTypeAttribute(
+      Element el, String attributeName, Class<? extends Entity> def) throws InvalidXMLException {
+    Node node = Node.fromAttr(el, attributeName);
+    return node == null ? def : parseEntityType(node);
   }
 
-  public static Class<? extends Projectile> parseProjectileType(Node node, String value)
+  public static Class<? extends Entity> parseEntityType(Node node) throws InvalidXMLException {
+    return parseEntityType(node, node.getValue());
+  }
+
+  public static Class<? extends Entity> parseEntityType(Node node, String value)
       throws InvalidXMLException {
     if (!value.matches("[a-zA-Z0-9_]+")) {
-      throw new InvalidXMLException("Invalid projectile type '" + value + "'", node);
+      throw new InvalidXMLException("Invalid entity type '" + value + "'", node);
     }
 
     try {
-      return Class.forName("org.bukkit.entity." + value).asSubclass(Projectile.class);
+      return Class.forName("org.bukkit.entity." + value).asSubclass(Entity.class);
     } catch (ClassNotFoundException | ClassCastException e) {
-      throw new InvalidXMLException("Invalid projectile type '" + value + "'", node);
+      throw new InvalidXMLException("Invalid entity type '" + value + "'", node);
     }
-  }
-
-  public static Class<? extends Projectile> parseProjectileTypeAttribute(
-      Element el, String attributeName, Class<? extends Projectile> def)
-      throws InvalidXMLException {
-    Node node = Node.fromAttr(el, attributeName);
-    return node == null ? def : parseProjectileType(node);
   }
 
   public static Vector parseVector(Node node, String value) throws InvalidXMLException {


### PR DESCRIPTION
Reverts previous commit wich removes the possibility for entities to be shot. And makes a way simpler fix for enderpearls.