### PR TITLE
Add a delay to 1.13 auto completion

### DIFF
--- a/deploy/server/plugins/ViaVersion/config.yml
+++ b/deploy/server/plugins/ViaVersion/config.yml
@@ -4,11 +4,11 @@ checkforupdates: false
 # Send supported protocol versions in pings
 send-supported-versions: true
 
-# Fix shift + double click not working when moving items 
+# Fix shift + double click not working when moving items
 quick-move-action-fix: true
 
 # Disable 1.13+ tab autocomplete issues
-disable-1_13-auto-complete: true
+1_13-tab-complete-delay: 10
 
 # Fix 1.13+ clients getting stuck in snow
 fix-low-snow-collision: true


### PR DESCRIPTION
From a long period of testing, I have noticed that disableing 1.13 completion is not necessary. 

In original PGM, you were kicked, and I disabled completions. In 1.8 PGM I was never kicked, but chat was spammed with red errors. Adding a `10` tick delay seemed to fix that, for the most part. Some people sometimes say they get errors, but it's very rare.

Not having auto completion is very annoying, and I think recommending a delay instead should fix most issues.

```yml
# 1.13 introduced new auto complete which can trigger "Kicked for spamming" for servers older than 1.13, the following option will disable it completely.
disable-1_13-auto-complete: false
# The following option will delay the tab complete request in x ticks if greater than 0, if other tab-complete is received, the previous is cancelled
1_13-tab-complete-delay: 10
```