### PR TITLE
Fix old match folder not deleted on map cycle, Resolves #63

### DIFF
--- a/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Iterables;
-
 import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.*;
@@ -793,8 +792,7 @@ public class MatchImpl implements Match, Comparable<Match> {
     final boolean unloaded = PGM.get().getServer().unloadWorld(worldName, true);
     if (!unloaded) {
       logger.log(
-          Level.SEVERE,
-          "Unable to unload world " + worldName + " (this can cause memory leaks!)");
+          Level.SEVERE, "Unable to unload world " + worldName + " (this can cause memory leaks!)");
     }
 
     schedulers.clear();


### PR DESCRIPTION
Simple fix, I tweaked the chunk unloading to remove unnecessary parameters. One thing worth noting is that even after unloading chunks, not all files would be unloaded. I got around that by setting the `save` flag on `getServer()#unloadWorld()` there seem to be complaints about it online - looks like an upstream bug. I couldn't find a ticket for it, and it's hard to say where the issue is within the stack. I'm wondering if this was causing some of the memory leaking as well, not sure though.