### PR TITLE
Clear best spawn points when farther one found

### DIFF
--- a/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
+++ b/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
@@ -41,6 +41,9 @@ public class SpreadPointProvider extends AggregatePointProvider {
         }
 
         if (bestDistance <= nearest) {
+          if (bestDistance != nearest) {
+            bestPoints.clear();
+          }
           bestDistance = nearest;
           bestPoints.add(pos);
         }


### PR DESCRIPTION
Fixed issue rightly pointed out by @Pablete1234 in his comment https://github.com/Electroid/PGM/pull/115#discussion_r358548082.

If a better spawn point was found it was appended to the existing list rather than overriding it.

Signed-off-by: Pugzy <pugzy@mail.com>