### PR TITLE
Make rotations resume on the server's last active one

### DIFF
--- a/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrder.java
+++ b/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrder.java
@@ -117,7 +117,7 @@ public class FixedPGMMapOrder implements PGMMapOrder {
   }
 
   PGMMap getMapInPosition(int position) {
-    if (position > maps.size()) {
+    if (position >= maps.size()) {
       PGM.get()
           .getLogger()
           .log(
@@ -130,7 +130,7 @@ public class FixedPGMMapOrder implements PGMMapOrder {
       return getMapInPosition(0);
     }
 
-    return maps.get(position % maps.size());
+    return maps.get(position);
   }
 
   @Override

--- a/src/main/resources/rotations.yml
+++ b/src/main/resources/rotations.yml
@@ -5,17 +5,20 @@
 #
 # NOTE: Map names are case-sensitive
 #
+# Record for the last active rotation on the server, so that it can be resumed upon shutdown/restart
+last_active: default
 
-default:
-  enabled: true
-  players: 1
-  # next_map helps the server resume rotations in the position they were before a server shutdown/restart
-  # The next map for default is the first map in it's map list.
-  # This only applies when the server creates the rotations.yml file for the first time
-  next_map: Airship Battle
-  maps:
-    - Airship Battle
-    - Harb
-    - Race for Victory
-    - The Fenland
-    - Warlock
+rotations:
+  default:
+    enabled: true
+    players: 1
+    # next_map helps the server resume rotations in the position they were before a server shutdown/restart
+    # The next map for default is the first map in it's map list.
+    # This only applies when the server creates the rotations.yml file for the first time
+    next_map: Airship Battle
+    maps:
+      - Airship Battle
+      - Harb
+      - Race for Victory
+      - The Fenland
+      - Warlock


### PR DESCRIPTION
Resolves being forced to have a "default" rotation, and it appears this is how it used to work before.