### PR TITLE
Fix rotations popping maps twice & overriding "/setnext"s

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/CycleCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/CycleCommands.java
@@ -37,7 +37,7 @@ public class CycleCommands {
           AllTranslations.get().translate("command.admin.cycle.matchRunning", sender));
     }
 
-    if (map != null) {
+    if (map != null && matchManager.getMapOrder().getNextMap() != map) {
       matchManager.getMapOrder().setNextMap(map);
       cmm.startCountdown(countdown, map);
     } else {

--- a/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
+++ b/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
@@ -13,7 +13,7 @@ import tc.oc.pgm.map.PGMMap;
 
 public class CycleCountdown extends MatchCountdown {
   protected final MatchManager mm;
-  protected final PGMMap nextMap;
+  protected PGMMap nextMap;
 
   public CycleCountdown(MatchManager mm, Match match, PGMMap nextMap) {
     super(match);
@@ -25,6 +25,9 @@ public class CycleCountdown extends MatchCountdown {
   protected Component formatText() {
     if (nextMap == null || nextMap.getInfo() == null) return BlankComponent.INSTANCE;
     Component mapName = new PersonalizedText(nextMap.getInfo().name, ChatColor.AQUA);
+
+    PGMMap expectedNextMap = mm.getMapOrder().getNextMap();
+    if (expectedNextMap != null && expectedNextMap != nextMap) nextMap = expectedNextMap;
 
     if (remaining.isLongerThan(Duration.ZERO)) {
       return new PersonalizedText(
@@ -40,9 +43,6 @@ public class CycleCountdown extends MatchCountdown {
   @Override
   public void onEnd(Duration total) {
     super.onEnd(total);
-    // For some reason, popNextMap() isn't being executed from within this function below
-    this.mm.cycleMatch(this.getMatch(), this.mm.getMapOrder().popNextMap(), false);
-    // This remains here for the above stated:
-    this.mm.getMapOrder().popNextMap();
+    this.mm.cycleMatch(this.getMatch(), mm.getMapOrder().popNextMap(), false);
   }
 }

--- a/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -62,10 +62,7 @@ public class CycleMatchModule extends MatchModule implements Listener {
     if (duration == null) duration = config.countdown();
     getMatch().finish();
     if (Duration.ZERO.equals(duration)) {
-      // For some reason, popNextMap() isn't being executed from within this function below
       mm.cycleMatch(getMatch(), mm.getMapOrder().popNextMap(), false);
-      // This remains here for the above stated:
-      mm.getMapOrder().popNextMap();
     } else {
       getMatch().getCountdown().start(new CycleCountdown(mm, getMatch(), nextMap), duration);
     }

--- a/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
@@ -183,7 +183,10 @@ public class FixedPGMMapOrderManager implements PGMMapOrder {
    * @return The {@link FixedPGMMapOrder} (Rotation) which matches the input name
    */
   public FixedPGMMapOrder getRotationByName(String name) {
-    return rotations.stream().filter(rot -> rot.getName().equals(name)).findFirst().orElse(null);
+    return rotations.stream()
+        .filter(rot -> rot.getName().equalsIgnoreCase(name))
+        .findFirst()
+        .orElse(null);
   }
 
   @Override


### PR DESCRIPTION
It took me a long while to figure out what was wrong with rotations popping maps twice *sometimes*, and the final explanation I found was that "/cycle" was checking for the passed argument to be null, which would very rarely, or even never be the case as if a map was not specified within the command body, it would `@Default("next")`, and therefore return the next map by rotation, that resulting in the map not being null, but rather the actual next map. 

The problem was that if the map happened to not be null, the cycle command would `setNextMap()` it, and that would cause the next map to be perceived as an overrider map by the `FixedPGMMapOrderManager`. In the end, an overrider map being present would prevent `popNextMap()` from rotating at all, and instead keep retrieving the same map over and over.