### PR TITLE
Fix upper bounds issue with dynamic rotation scaling

### DIFF
--- a/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
@@ -120,10 +120,9 @@ public class FixedPGMMapOrderManager implements PGMMapOrder {
     rotations.stream()
         .filter(FixedPGMMapOrder::isEnabled)
         .map(FixedPGMMapOrder::getPlayers)
-        .sorted()
         .filter(playerCount -> playerCount >= activePlayers)
+        .min(Integer::compareTo)
         .map(this::getRotationByPlayerCount)
-        .findFirst()
         .ifPresent(this::updateActiveRotation);
   }
 

--- a/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/FixedPGMMapOrderManager.java
@@ -117,17 +117,14 @@ public class FixedPGMMapOrderManager implements PGMMapOrder {
   public void recalculateActiveRotation() {
     int activePlayers = getActivePlayers();
 
-    FixedPGMMapOrder newRotation =
-        rotations.stream()
-            .filter(FixedPGMMapOrder::isEnabled)
-            .map(FixedPGMMapOrder::getPlayers)
-            .sorted()
-            .filter(playerCount -> playerCount >= activePlayers)
-            .map(this::getRotationByPlayerCount)
-            .findFirst()
-            .orElse(null);
-
-    updateActiveRotation(newRotation);
+    rotations.stream()
+        .filter(FixedPGMMapOrder::isEnabled)
+        .map(FixedPGMMapOrder::getPlayers)
+        .sorted()
+        .filter(playerCount -> playerCount >= activePlayers)
+        .map(this::getRotationByPlayerCount)
+        .findFirst()
+        .ifPresent(this::updateActiveRotation);
   }
 
   private int getActivePlayers() {


### PR DESCRIPTION
Signed-off-by: botinator <53882853+botinator@users.noreply.github.com>

There was an issue in production on the `oc.tc` server where when the player count exceeded the last rotation option in the dynamic scaling rotation list it would set `updateActiveRotation` to null and freeze the server.