### PR TITLE
Fix rotation ordering going backwards

### DIFF
--- a/src/main/java/tc/oc/pgm/rotation/RotationManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/RotationManager.java
@@ -90,7 +90,7 @@ public class RotationManager implements PGMMapOrder {
 
     rotations.stream()
         .filter(rot -> activePlayers >= rot.getPlayers())
-        .min(Rotation::compareTo)
+        .max(Rotation::compareTo)
         .ifPresent(this::updateActiveRotation);
   }
 


### PR DESCRIPTION
The order of rotations trries to get the smallest one, instead of biggest one that can load