### PR TITLE
Alias /all to /g command

### DIFF
--- a/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -41,7 +41,7 @@ public class ChatDispatcher implements Listener {
   }
 
   @Command(
-      aliases = {"g"},
+      aliases = {"g", "all"},
       desc = "Send a message to everyone",
       usage = "[message]")
   public void sendGlobal(Match match, MatchPlayer sender, @Nullable @Text String message) {


### PR DESCRIPTION
`/all` is used to type in global chat in League of Legends. Might be helpful to some players who are used to `/all`