### PR TITLE
Add CommandBook teleport permissions

### DIFF
--- a/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -105,6 +105,7 @@ public interface Permissions {
               .putAll(DISABLE.getChildren())
               .put("worldedit.navigation.jumpto.tool", false)
               .put("worldedit.navigation.thru.tool", false)
+              .put("commandbook.teleport", false)
               .build());
   Permission OBSERVER =
       new Permission(
@@ -113,6 +114,7 @@ public interface Permissions {
           new ImmutableMap.Builder<String, Boolean>()
               .putAll(DISABLE.getChildren())
               .put("worldedit.navigation.*", true)
+              .put("commandbook.teleport", true)
               .build());
 
   static void register(PluginManager pluginManager) {


### PR DESCRIPTION
Adds CommandBook permission nodes for observers to teleport and revokes for participants.

This could be implemented later as a configurable list, however, this class currently includes other commandbook and worldedit permission nodes and a quick fix is needed.

Signed-off-by: Pugzy <pugzy@mail.com>