### PR TITLE
Add basic report command with alert and event

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -451,6 +451,12 @@ command.class.view.list = List all classes by typing '/classes'
 command.development.clearErrors.success = Errors cleared!
 command.development.listErrors.noErrors = No errors!
 
+# {0} = sender
+# {1} = accused
+# {2} = reason
+command.report.notify = {0} reported {1}: {2}
+command.report.acknowledge = The issue will be dealt with shortly.
+
 # {0} = team name
 ffa.join = You joined the match
 team.join = You joined {0}
@@ -515,6 +521,7 @@ misc.ownership = {0}'s {1}
 
 misc.by = by
 misc.team = Team
+misc.thankYou = Thank you.
 
 command.map.mapList.title = Maps
 

--- a/src/main/java/tc/oc/pgm/PGMImpl.java
+++ b/src/main/java/tc/oc/pgm/PGMImpl.java
@@ -486,6 +486,7 @@ public final class PGMImpl extends JavaPlugin implements PGM {
     node.registerCommands(new TimeLimitCommands());
     node.registerCommands(new MapPoolCommands());
     node.registerCommands(new SettingCommands());
+    node.registerCommands(new ModerationCommands());
 
     new BukkitIntake(this, graph).register();
   }

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -1,0 +1,70 @@
+package tc.oc.pgm.commands;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.parametric.annotation.Text;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.component.Component;
+import tc.oc.component.types.PersonalizedText;
+import tc.oc.component.types.PersonalizedTranslatable;
+import tc.oc.named.NameStyle;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.chat.Audience;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.PlayerReportEvent;
+
+public class ModerationCommands {
+
+  @Command(
+      aliases = {"report"},
+      usage = "<player> <reason>",
+      desc = "Report a player who is breaking the rules")
+  public static void report(
+      CommandSender commandSender,
+      MatchPlayer matchPlayer,
+      Match match,
+      Player player,
+      @Text String reason) {
+    MatchPlayer accused = match.getPlayer(player);
+    PlayerReportEvent event = new PlayerReportEvent(commandSender, accused, reason);
+    match.callEvent(event);
+
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        commandSender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    }
+
+    commandSender.sendMessage(
+        new PersonalizedText(
+            new PersonalizedText(new PersonalizedTranslatable("misc.thankYou"), ChatColor.GREEN),
+            new PersonalizedText(" "),
+            new PersonalizedText(
+                new PersonalizedTranslatable("command.report.acknowledge"), ChatColor.GOLD)));
+
+    final Component component =
+        new PersonalizedTranslatable(
+            "command.report.notify",
+            matchPlayer == null
+                ? new PersonalizedText("Console", ChatColor.AQUA, ChatColor.ITALIC)
+                : matchPlayer.getStyledName(NameStyle.FANCY),
+            accused.getStyledName(NameStyle.FANCY),
+            new PersonalizedText(reason.trim(), ChatColor.WHITE));
+
+    final Component prefixedComponent =
+        new PersonalizedText(
+            new PersonalizedText("["),
+            new PersonalizedText("A", ChatColor.GOLD),
+            new PersonalizedText("] "),
+            new PersonalizedText(component, ChatColor.YELLOW));
+
+    match.getPlayers().stream()
+        .filter(viewer -> viewer.getBukkit().hasPermission(Permissions.ADMINCHAT))
+        .forEach(viewer -> viewer.sendMessage(prefixedComponent));
+    Audience.get(Bukkit.getConsoleSender()).sendMessage(component);
+  }
+}

--- a/src/main/java/tc/oc/pgm/events/PlayerReportEvent.java
+++ b/src/main/java/tc/oc/pgm/events/PlayerReportEvent.java
@@ -1,0 +1,45 @@
+package tc.oc.pgm.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.event.ExtendedCancellable;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+/** Called immediately AFTER a player runs the report command. */
+public class PlayerReportEvent extends ExtendedCancellable {
+
+  private final CommandSender sender;
+  private final MatchPlayer player;
+  private final String reason;
+
+  public PlayerReportEvent(CommandSender sender, MatchPlayer player, String reason) {
+    this.sender = checkNotNull(sender);
+    this.player = checkNotNull(player);
+    this.reason = checkNotNull(reason);
+  }
+
+  public CommandSender getSender() {
+    return sender;
+  }
+
+  public MatchPlayer getPlayer() {
+    return player;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}


### PR DESCRIPTION
Adds a basic report command which takes a player and a reason. This triggers a `PlayerReportEvent` and sends a formatted message to all players with the permission `Permissions.ADMINCHAT`.

e.g. image below (both player names are clickable, ignore my messed up flairs)

![image](https://user-images.githubusercontent.com/8608892/71695923-7ee7cf00-2dab-11ea-85a8-34c61f92bd75.png)

Signed-off-by: Pugzy <pugzy@mail.com>