### PR TITLE
Add a setting to toggle displaying the picker

### DIFF
--- a/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -9,7 +9,8 @@ import static tc.oc.pgm.api.setting.SettingValue.*;
  */
 public enum SettingKey {
   CHAT("chat", CHAT_TEAM, CHAT_GLOBAL, CHAT_ADMIN), // Changes the default chat channel
-  DEATH("death", DEATH_OWN, DEATH_ALL); // Changes which death messages are seen
+  DEATH("death", DEATH_OWN, DEATH_ALL), // Changes which death messages are seen
+  PICKER("picker", PICKER_DISPLAY, PICKER_HIDE); // Changes if the picker is displayed or not
 
   private final String name;
   private final SettingValue[] values;

--- a/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -10,7 +10,7 @@ import static tc.oc.pgm.api.setting.SettingValue.*;
 public enum SettingKey {
   CHAT("chat", CHAT_TEAM, CHAT_GLOBAL, CHAT_ADMIN), // Changes the default chat channel
   DEATH("death", DEATH_OWN, DEATH_ALL), // Changes which death messages are seen
-  PICKER("picker", PICKER_DISPLAY, PICKER_HIDE); // Changes if the picker is displayed or not
+  PICKER("picker", PICKER_AUTO, PICKER_ON, PICKER_OFF); // Changes when the picker is displayed
 
   private final String name;
   private final SettingValue[] values;

--- a/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -19,8 +19,9 @@ public enum SettingValue {
   CHAT_ADMIN("chat", "admin"), // Send to all server operators
   DEATH_OWN("death", "own"), // Only send death messages involving self
   DEATH_ALL("death", "all"), // Send all death messages, highlight your own
-  PICKER_DISPLAY("picker", "show"), // Display the picker GUI when clicked
-  PICKER_HIDE("picker", "hide"); // Hide the picker GUI, will auto join a team when clicked
+  PICKER_AUTO("picker", "auto"), // Display after cycle, or with permissions.
+  PICKER_ON("picker", "on"), // Display the picker GUI always
+  PICKER_OFF("picker", "off"); // Never display the picker GUI
 
   private final String key;
   private final String name;

--- a/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -18,7 +18,9 @@ public enum SettingValue {
   CHAT_GLOBAL("chat", "global"), // Send to all players in the same match
   CHAT_ADMIN("chat", "admin"), // Send to all server operators
   DEATH_OWN("death", "own"), // Only send death messages involving self
-  DEATH_ALL("death", "all"); // Send all death messages, highlight your own
+  DEATH_ALL("death", "all"), // Send all death messages, highlight your own
+  PICKER_DISPLAY("picker", "display"), // Display the picker GUI when clicked
+  PICKER_HIDE("picker", "hide"); // Hide the picker GUI, will auto join a team when clicked
 
   private final String key;
   private final String name;

--- a/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -19,7 +19,7 @@ public enum SettingValue {
   CHAT_ADMIN("chat", "admin"), // Send to all server operators
   DEATH_OWN("death", "own"), // Only send death messages involving self
   DEATH_ALL("death", "all"), // Send all death messages, highlight your own
-  PICKER_DISPLAY("picker", "display"), // Display the picker GUI when clicked
+  PICKER_DISPLAY("picker", "show"), // Display the picker GUI when clicked
   PICKER_HIDE("picker", "hide"); // Hide the picker GUI, will auto join a team when clicked
 
   private final String key;

--- a/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -90,7 +90,7 @@ public class PickerMatchModule extends MatchModule implements Listener {
     this.isBlitz = match.hasMatchModule(BlitzMatchModule.class);
   }
 
-  protected boolean settingEnabled(MatchPlayer player, boolean isJoinButton) {
+  protected boolean settingEnabled(MatchPlayer player, boolean playerTriggered) {
     boolean hasPermission = player.getBukkit().hasPermission(Permissions.JOIN_CHOOSE);
     switch (player.getSettings().getValue(SettingKey.PICKER)) {
       case PICKER_OFF: // When off never show GUI
@@ -98,7 +98,7 @@ public class PickerMatchModule extends MatchModule implements Listener {
       case PICKER_ON: // When on always show the GUI
         return true;
       default: // Display after map cycle, but check perms when clicking button.
-        return (isJoinButton ? hasPermission : true);
+        return (playerTriggered ? hasPermission : true);
     }
   }
 

--- a/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -27,6 +27,7 @@ import org.bukkit.material.MaterialData;
 import tc.oc.item.Items;
 import tc.oc.pgm.AllTranslations;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.chat.Sound;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
@@ -34,7 +35,6 @@ import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
-import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.classes.PlayerClass;
@@ -90,8 +90,16 @@ public class PickerMatchModule extends MatchModule implements Listener {
     this.isBlitz = match.hasMatchModule(BlitzMatchModule.class);
   }
 
-  protected boolean settingEnabled(MatchPlayer player) {
-    return player.getSettings().getValue(SettingKey.PICKER) == SettingValue.PICKER_DISPLAY;
+  protected boolean settingEnabled(MatchPlayer player, boolean isJoinButton) {
+    boolean hasPermission = player.getBukkit().hasPermission(Permissions.JOIN_CHOOSE);
+    switch (player.getSettings().getValue(SettingKey.PICKER)) {
+      case PICKER_OFF: // When off never show GUI
+        return false;
+      case PICKER_ON: // When on always show the GUI
+        return true;
+      default: // Display after map cycle, but check perms when clicking button.
+        return (isJoinButton ? hasPermission : true);
+    }
   }
 
   private boolean hasJoined(MatchPlayer joining) {
@@ -151,12 +159,10 @@ public class PickerMatchModule extends MatchModule implements Listener {
   /**
    * Does the player have any use for the picker dialog? If the player can join, but there is
    * nothing to pick (i.e. FFA without classes) then this returns false, while {@link #canUse}
-   * returns true. Also takes into account whether the player has the picker setting enabled.
+   * returns true.
    */
   private boolean canOpenWindow(MatchPlayer player) {
-    return canUse(player)
-        && settingEnabled(player)
-        && (hasClasses || canChooseMultipleTeams(player));
+    return canUse(player) && (hasClasses || canChooseMultipleTeams(player));
   }
 
   private boolean isPicking(MatchPlayer player) {
@@ -256,7 +262,7 @@ public class PickerMatchModule extends MatchModule implements Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void join(PlayerJoinMatchEvent event) {
     final MatchPlayer player = event.getPlayer();
-    if (!settingEnabled(player)) return;
+    if (!settingEnabled(player, false)) return;
 
     if (canOpenWindow(player)) {
       event
@@ -322,10 +328,10 @@ public class PickerMatchModule extends MatchModule implements Listener {
 
     if (hand.getType() == Button.JOIN.material) {
       handled = true;
-      if (canOpenWindow(player)) {
+      if (canOpenWindow(player) && settingEnabled(player, true)) {
         showWindow(player);
       } else {
-        // If there is nothing to pick, just join immediately
+        // If there is nothing to pick or setting is disabled, just join immediately
         jmm.join(player, null);
       }
     } else if (hand.getType() == Button.LEAVE.material) {

--- a/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -33,6 +33,8 @@ import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.classes.PlayerClass;
@@ -89,7 +91,7 @@ public class PickerMatchModule extends MatchModule implements Listener {
   }
 
   protected boolean settingEnabled(MatchPlayer player) {
-    return true;
+    return player.getSettings().getValue(SettingKey.PICKER) == SettingValue.PICKER_DISPLAY;
   }
 
   private boolean hasJoined(MatchPlayer joining) {
@@ -149,10 +151,12 @@ public class PickerMatchModule extends MatchModule implements Listener {
   /**
    * Does the player have any use for the picker dialog? If the player can join, but there is
    * nothing to pick (i.e. FFA without classes) then this returns false, while {@link #canUse}
-   * returns true.
+   * returns true. Also takes into account whether the player has the picker setting enabled.
    */
   private boolean canOpenWindow(MatchPlayer player) {
-    return canUse(player) && (hasClasses || canChooseMultipleTeams(player));
+    return canUse(player)
+        && settingEnabled(player)
+        && (hasClasses || canChooseMultipleTeams(player));
   }
 
   private boolean isPicking(MatchPlayer player) {


### PR DESCRIPTION
**Added a setting to toggle the picker visibility.** 

Personally I believe players should have the choice to toggle the picker GUI off. With a large majority of players not having the ability to choose their team, I think many will find this useful. However I did make it so the “displaying” option is on by default.


~~On a side note, I wanted to make the setting values easy to understand (“hide” and “display”). Though if there are any better recommendations I am open to suggestions.~~

Edit:
We’ve updated “display” -> “show”, as it’s more user friendly. 
(I’m not going to update the screenshot, sorry 😆)

Edit 2 (1/3/2020): Please note screenshot is now outdated. See below comments to view updated setting values.

Example of setting values:
![Screen Shot 2020-01-02 at 3 13 45 PM](https://user-images.githubusercontent.com/3377659/71699464-77590380-2d74-11ea-9c87-b2374900fe33.png)


Example of when picker is hidden:
![Screen Recording 2020-01-02 at 12 48 PM](https://user-images.githubusercontent.com/3377659/71699484-95beff00-2d74-11ea-9ec9-d64535993d3f.gif)




Signed-off-by: applenick <applenick@users.noreply.github.com>