### PR TITLE
Fix incomplete symbol used on simple goals

### DIFF
--- a/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
+++ b/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
@@ -19,7 +19,7 @@ public abstract class SimpleGoal<T extends GoalDefinition> implements Goal<T> {
   public static final ChatColor COLOR_INCOMPLETE = ChatColor.RED;
   public static final ChatColor COLOR_COMPLETE = ChatColor.GREEN;
 
-  public static final String SYMBOL_INCOMPLETE = "\u274c"; // ❌
+  public static final String SYMBOL_INCOMPLETE = "\u2715"; // ✕
   public static final String SYMBOL_COMPLETE = "\u2714"; // ✔
 
   protected final Logger logger;


### PR DESCRIPTION
Reverts a change made by Pablete in 6aee67bffac1b54a30f14f6a795b6901d19143f2 where the symbol was changed to one that is not supported in-game.

Signed-off-by: Pugzy <pugzy@mail.com>