### PR TITLE
Fix rage game component

### DIFF
--- a/src/main/java/tc/oc/pgm/rage/RageModule.java
+++ b/src/main/java/tc/oc/pgm/rage/RageModule.java
@@ -41,7 +41,7 @@ public class RageModule extends MapModule {
   public static RageModule parse(MapModuleContext context, Logger logger, Document doc) {
 
     if (doc.getRootElement().getChild("rage") != null) {
-      BlitzModule blitzModule = context.getModule(BlitzModule.class);
+      BlitzModule blitzModule = context.needModule(BlitzModule.class);
       return new RageModule(!blitzModule.isDisabled(null));
     } else {
       return null;

--- a/src/main/java/tc/oc/pgm/rage/RageModule.java
+++ b/src/main/java/tc/oc/pgm/rage/RageModule.java
@@ -41,7 +41,8 @@ public class RageModule extends MapModule {
   public static RageModule parse(MapModuleContext context, Logger logger, Document doc) {
 
     if (doc.getRootElement().getChild("rage") != null) {
-      return new RageModule(context.hasModule(BlitzModule.class));
+      BlitzModule blitzModule = context.getModule(BlitzModule.class);
+      return new RageModule(!blitzModule.isDisabled(null));
     } else {
       return null;
     }


### PR DESCRIPTION
That's because `BlitzModule` is always parsed and therefore always exists.

https://github.com/TheMolkaPL/PGM-1/blob/0989c7431b5159fedd2b68ba3327ec3b5a71ea99/src/main/java/tc/oc/pgm/blitz/BlitzModule.java#L55-L67

Related: https://github.com/Electroid/PGM/issues/184