### PR TITLE
Don't suggest setting key aliases

### DIFF
--- a/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -42,9 +42,9 @@ public enum SettingKey {
   }
 
   /**
-   * Get all aliases of this {@link SettingKey}.
+   * Get all aliases of this {@link SettingKey}. First index is always equal to {@code #getName}.
    *
-   * @return An immutable list of all aliases.
+   * @return An immutable list of all aliases. Never {@code null} or empty.
    */
   public List<String> getAliases() {
     return aliases;

--- a/src/main/java/tc/oc/pgm/commands/provider/SettingKeyProvider.java
+++ b/src/main/java/tc/oc/pgm/commands/provider/SettingKeyProvider.java
@@ -42,9 +42,11 @@ public class SettingKeyProvider implements BukkitProvider<SettingKey> {
 
     List<String> suggestions = new ArrayList<>();
     for (SettingKey settingKey : SettingKey.values()) {
-      String name = settingKey.getName();
-      if (name.toLowerCase().startsWith(query.toLowerCase())) {
-        suggestions.add(name);
+      for (String alias : settingKey.getAliases()) {
+        if (alias.toLowerCase().startsWith(query.toLowerCase())) {
+          suggestions.add(alias);
+          break; // don't suggest more aliases for this setting
+        }
       }
     }
 

--- a/src/main/java/tc/oc/pgm/commands/provider/SettingKeyProvider.java
+++ b/src/main/java/tc/oc/pgm/commands/provider/SettingKeyProvider.java
@@ -42,10 +42,9 @@ public class SettingKeyProvider implements BukkitProvider<SettingKey> {
 
     List<String> suggestions = new ArrayList<>();
     for (SettingKey settingKey : SettingKey.values()) {
-      for (String alias : settingKey.getAliases()) {
-        if (alias.toLowerCase().startsWith(query.toLowerCase())) {
-          suggestions.add(alias);
-        }
+      String name = settingKey.getName();
+      if (name.toLowerCase().startsWith(query.toLowerCase())) {
+        suggestions.add(name);
       }
     }
 


### PR DESCRIPTION
Currently, after typing `/toggle ` it suggests all available aliases, which is confusing, as it looks like there are more settings.