### PR TITLE
Improve maptags

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -103,7 +103,7 @@ public class MapCommands {
 
     MapPersistentContext persistentContext = map.getPersistentContext();
     Set<MapTag> mapTags = persistentContext.getMapTags();
-    audience.sendMessage(createTagsComponent(mapTags).color(ChatColor.DARK_AQUA));
+    audience.sendMessage(createTagsComponent(mapTags).color(ChatColor.GRAY));
 
     Component edition = new PersonalizedText(mapInfo.getLocalizedEdition(), ChatColor.GOLD);
     if (!edition.toPlainText().isEmpty()) {

--- a/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -102,8 +102,6 @@ public class MapCommands {
     audience.sendMessage(mapInfo.getFormattedMapTitle());
 
     MapPersistentContext persistentContext = map.getPersistentContext();
-    Set<MapTag> mapTags = persistentContext.getMapTags();
-    audience.sendMessage(createTagsComponent(mapTags).color(ChatColor.GRAY));
 
     Component edition = new PersonalizedText(mapInfo.getLocalizedEdition(), ChatColor.GOLD);
     if (!edition.toPlainText().isEmpty()) {
@@ -185,6 +183,9 @@ public class MapCommands {
                       new PersonalizedTranslatable("command.map.mapInfo.sourceCode.tip")
                           .render())));
     }
+
+    Set<MapTag> mapTags = persistentContext.getMapTags();
+    audience.sendMessage(createTagsComponent(mapTags).color(ChatColor.YELLOW));
   }
 
   private static Component createTagsComponent(Set<MapTag> tags) {

--- a/src/main/java/tc/oc/pgm/damage/DisableDamageModule.java
+++ b/src/main/java/tc/oc/pgm/damage/DisableDamageModule.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.damage;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import java.util.Set;
 import java.util.logging.Logger;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.jdom2.Document;
@@ -10,6 +11,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.PlayerRelation;
 import tc.oc.pgm.map.MapModule;
 import tc.oc.pgm.map.MapModuleContext;
+import tc.oc.pgm.maptag.MapTag;
 import tc.oc.pgm.module.ModuleDescription;
 import tc.oc.pgm.util.XMLUtils;
 import tc.oc.xml.InvalidXMLException;
@@ -17,10 +19,18 @@ import tc.oc.xml.Node;
 
 @ModuleDescription(name = "DisableDamage")
 public class DisableDamageModule extends MapModule<DisableDamageMatchModule> {
+
+  private static final MapTag NOFALLDAMAGE_TAG = MapTag.forName("nofalldamage");
+
   protected final SetMultimap<DamageCause, PlayerRelation> causes;
 
   public DisableDamageModule(SetMultimap<DamageCause, PlayerRelation> causes) {
     this.causes = causes;
+  }
+
+  @Override
+  public void loadTags(Set<MapTag> tags) {
+    if (causes.containsKey(DamageCause.FALL)) tags.add(NOFALLDAMAGE_TAG);
   }
 
   @Override

--- a/src/main/java/tc/oc/pgm/teams/TeamModule.java
+++ b/src/main/java/tc/oc/pgm/teams/TeamModule.java
@@ -28,7 +28,6 @@ import tc.oc.xml.Node;
     requires = {InfoModule.class, StartModule.class})
 public class TeamModule extends MapModule<TeamMatchModule> {
 
-  private static final MapTag _4TEAMS_TAG = MapTag.forName("4teams");
   private static final MapTag EVENTEAMS_TAG = MapTag.forName("eventeams");
   private static final MapTag TEAMS_TAG = MapTag.forName("teams");
 
@@ -47,7 +46,7 @@ public class TeamModule extends MapModule<TeamMatchModule> {
 
   @Override
   public void loadTags(Set<MapTag> tags) {
-    if (teams.size() == 4) tags.add(_4TEAMS_TAG);
+    tags.add(MapTag.forName(teams.size() + (teams.size() == 1 ? "team" : "teams")));
     if (requireEven != null && requireEven) tags.add(EVENTEAMS_TAG);
     tags.add(TEAMS_TAG);
   }


### PR DESCRIPTION
* Make maptags in the /map command gray
* Always tag maps with amount of team(s)
* `#nofalldamage` when fall damage is disabled

As requested by @RuedigerLP