### PR TITLE
Add the ability to forfeit a match

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -850,3 +850,25 @@ misc.seconds.pluralCompound = {0} seconds
 # {1} = the total pages
 pageHeader = Page {0} of {1}
 currentPage = Page {0}
+
+command.forfeit.notEnabled = Forfeit is not enabled at this time.
+command.forfeit.notPossible = It is not possible to forfeit this match.
+command.forfeit.observers = Only active participants can use /forfeit
+
+command.forfeit.disable = You have disabled /forfeit for this match.
+command.forfeit.enable = You have enabled /forfeit for this match.
+
+# {0} = forfeit status
+command.forfeit.voted = You have voted to end the match. ({0})
+command.forfeit.withdraw = You have withdrawn your forfeit vote.
+
+# {0} = player name
+# {1} = forfeit status
+forfeit.broadcast.vote = {0} has voted to end the match. ({1})
+forfeit.broadcast.withdraw = {0} has withdrawn their forfeit vote.
+
+# {0} = Total Forfeits
+# {1} = Total players
+forfeit.broadcast.stats = {0} / {1} votes
+
+forfeit.broadcast.hover = Click to vote in favor of ending the match.

--- a/src/main/java/tc/oc/pgm/Config.java
+++ b/src/main/java/tc/oc/pgm/Config.java
@@ -408,4 +408,18 @@ public class Config {
       return getConfiguration().getBoolean("sidebar.overwrite", false);
     }
   }
+
+  public static class Forfeit {
+    public static boolean enabled() {
+      return getConfiguration().getBoolean("forfeit.enabled", false);
+    }
+
+    public static boolean isBroadcastEnabled() {
+      return getConfiguration().getBoolean("forfeit.broadcast-votes", false);
+    }
+
+    public static int getMaxPlayerCount() {
+      return getConfiguration().getInt("forfeit.max-players", 10);
+    }
+  }
 }

--- a/src/main/java/tc/oc/pgm/PGMImpl.java
+++ b/src/main/java/tc/oc/pgm/PGMImpl.java
@@ -100,6 +100,7 @@ import tc.oc.pgm.module.ModuleRegistry;
 import tc.oc.pgm.modules.ArrowRemovalModule;
 import tc.oc.pgm.modules.DiscardPotionBottlesModule;
 import tc.oc.pgm.modules.EventFilterMatchModule;
+import tc.oc.pgm.modules.ForfeitMatchModule;
 import tc.oc.pgm.modules.FriendlyFireRefundModule;
 import tc.oc.pgm.modules.InfoModule;
 import tc.oc.pgm.modules.InternalModule;
@@ -420,6 +421,7 @@ public final class PGMImpl extends JavaPlugin implements PGM {
     factory.register(ViewInventoryMatchModule.class, new ViewInventoryMatchModule.Factory());
     factory.register(JoinMatchModule.class, new JoinMatchModule.Factory());
     factory.register(CycleMatchModule.class, new CycleMatchModule.Factory());
+    factory.register(ForfeitMatchModule.class, new ForfeitMatchModule.Factory());
 
     return factory;
   }
@@ -493,6 +495,7 @@ public final class PGMImpl extends JavaPlugin implements PGM {
     node.registerCommands(new MapPoolCommands());
     node.registerCommands(new SettingCommands());
     node.registerCommands(new ModerationCommands());
+    node.registerCommands(new ForfeitCommands());
 
     new BukkitIntake(this, graph).register();
   }

--- a/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -152,6 +152,13 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
    */
   boolean canSee(MatchPlayer other);
 
+  /**
+   * Get whether the {@link MatchPlayer} has decided to forfeit the match.
+   *
+   * @return Whether the {@link MatchPlayer} has forfeit.
+   */
+  boolean hasForfeit();
+
   /** Reset the {@link MatchPlayer} when changing between {@link org.bukkit.GameMode}s. */
   void resetGamemode();
 
@@ -185,6 +192,13 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
    * @param frozen Whether to be frozen.
    */
   void setFrozen(boolean frozen);
+
+  /**
+   * Mark the {@link MatchPlayer} decision to forfeit.
+   *
+   * @param forfeit Whether to forfeit the match.
+   */
+  void setForfeit(boolean forfeit);
 
   /**
    * Apply a {@link Kit} to the {@link MatchPlayer}.

--- a/src/main/java/tc/oc/pgm/commands/ForfeitCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ForfeitCommands.java
@@ -1,0 +1,46 @@
+package tc.oc.pgm.commands;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.parametric.annotation.Switch;
+import java.util.Optional;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.command.CommandSender;
+import tc.oc.component.types.PersonalizedTranslatable;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.modules.ForfeitMatchModule;
+
+public class ForfeitCommands {
+
+  @Command(
+      aliases = {"forfeit"},
+      desc = "Vote to forfeit the match")
+  public static void forfeitMatch(
+      CommandSender sender, Match match, MatchPlayer player, @Switch('t') boolean toggle) {
+    Optional<ForfeitMatchModule> forfeit = match.getModule(ForfeitMatchModule.class);
+    if (forfeit.isPresent()) {
+      ForfeitMatchModule fmm = forfeit.get();
+
+      if (sender.hasPermission(Permissions.STAFF) && toggle) {
+        boolean newStatus = fmm.setEnabled(!fmm.isEnabled());
+
+        sender.sendMessage(
+            new PersonalizedTranslatable(
+                    newStatus ? "command.forfeit.enable" : "command.forfeit.disable")
+                .getPersonalizedText()
+                .color(ChatColor.GRAY));
+      } else {
+        if (fmm.isEnabled()) {
+          if (player.isObserving()) {
+            player.sendWarning(new PersonalizedTranslatable("command.forfeit.observers"));
+          } else {
+            fmm.forfeit(player, sender);
+          }
+        } else {
+          player.sendWarning(new PersonalizedTranslatable("command.forfeit.notEnabled"));
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -62,6 +62,7 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
   private final AtomicBoolean frozen;
   private final AtomicBoolean dead;
   private final AtomicBoolean visible;
+  private final AtomicBoolean forfeit;
 
   public MatchPlayerImpl(Match match, Player player) {
     this.logger =
@@ -75,6 +76,7 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
     this.frozen = new AtomicBoolean(false);
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
+    this.forfeit = new AtomicBoolean(false);
   }
 
   @Override
@@ -166,6 +168,11 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
   @Override
   public boolean isFrozen() {
     return frozen.get();
+  }
+
+  @Override
+  public boolean hasForfeit() {
+    return forfeit.get();
   }
 
   @Override
@@ -293,6 +300,11 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
         resetGamemode();
       }
     }
+  }
+
+  @Override
+  public void setForfeit(boolean yes) {
+    forfeit.set(yes);
   }
 
   /**

--- a/src/main/java/tc/oc/pgm/modules/ForfeitMatchModule.java
+++ b/src/main/java/tc/oc/pgm/modules/ForfeitMatchModule.java
@@ -1,0 +1,148 @@
+package tc.oc.pgm.modules;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import org.bukkit.command.CommandSender;
+import tc.oc.component.Component;
+import tc.oc.component.types.PersonalizedText;
+import tc.oc.component.types.PersonalizedTranslatable;
+import tc.oc.named.NameStyle;
+import tc.oc.pgm.Config;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.match.MatchModule;
+import tc.oc.pgm.match.MatchModuleFactory;
+import tc.oc.pgm.module.ModuleLoadException;
+import tc.oc.pgm.teams.TeamMatchModule;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
+
+public class ForfeitMatchModule extends MatchModule {
+
+  public static class Factory implements MatchModuleFactory<ForfeitMatchModule> {
+    @Override
+    public ForfeitMatchModule createMatchModule(Match match) throws ModuleLoadException {
+      return new ForfeitMatchModule(match);
+    }
+  }
+
+  private boolean enabled;
+  private boolean broadcastEnabled;
+  private int maxPlayers;
+
+  public ForfeitMatchModule(Match match) {
+    super(match);
+    enabled = Config.Forfeit.enabled();
+    broadcastEnabled = Config.Forfeit.isBroadcastEnabled();
+    maxPlayers = Config.Forfeit.getMaxPlayerCount();
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public boolean setEnabled(boolean on) {
+    enabled = on;
+    return isEnabled();
+  }
+
+  public int getTotalForfeits() {
+    return match.getParticipants().stream()
+        .filter(MatchPlayer::hasForfeit)
+        .collect(Collectors.counting())
+        .intValue();
+  }
+
+  public int getMatchPlayerCount() {
+    return match.getParticipants().size();
+  }
+
+  public void forfeit(MatchPlayer player, CommandSender sender) {
+    if (isForfietPossible()) {
+      player.setForfeit(!player.hasForfeit());
+      broadcastForfeit(player, player.hasForfeit());
+      calcForfeit(player);
+    } else {
+      player.sendWarning(new PersonalizedTranslatable("command.forfeit.notPossible"));
+    }
+  }
+
+  /*
+   * Current Restrictions:
+   * 1. If the match has a time limit.
+   * 2. If the match does not contain teams.
+   * 3. If player count is more than the max-player config.
+   */
+  private boolean isForfietPossible() {
+    Optional<TeamMatchModule> tmm = match.getModule(TeamMatchModule.class);
+    Optional<TimeLimitMatchModule> tlmm = match.getModule(TimeLimitMatchModule.class);
+
+    boolean hasTeams = tmm.isPresent();
+    boolean hasTimeLimit = tlmm.isPresent() && tlmm.get().hasTimeLimit();
+    boolean underPlayerLimit = maxPlayers != 0 ? getMatchPlayerCount() <= maxPlayers : true;
+
+    return isEnabled() && match.isRunning() && !hasTimeLimit && hasTeams && underPlayerLimit;
+  }
+
+  private void broadcastForfeit(MatchPlayer voter, boolean forfeit) {
+    if (broadcastEnabled) {
+      match
+          .getParticipants()
+          .forEach(p -> p.sendMessage(getForfeitBroadcast(voter, forfeit, p.hasForfeit())));
+      match.getObservers().forEach(o -> o.sendMessage(getForfeitBroadcast(voter, forfeit, false)));
+    } else {
+      voter.sendMessage(getForfeitCommandMessage(forfeit));
+    }
+  }
+
+  public void calcForfeit(MatchPlayer voter) {
+    boolean remaining =
+        match.getParticipants().stream()
+            .filter(player -> !player.hasForfeit())
+            .findAny()
+            .isPresent();
+
+    if (!remaining) {
+      match.finish(null);
+    }
+  }
+
+  private Component getForfeitStatusComponent() {
+    Component totalForfeits = new PersonalizedText("" + getTotalForfeits()).color(ChatColor.GREEN);
+    Component totalNeeded = new PersonalizedText("" + getMatchPlayerCount()).color(ChatColor.RED);
+    return new PersonalizedTranslatable("forfeit.broadcast.stats", totalForfeits, totalNeeded);
+  }
+
+  private Component getForfeitCommandMessage(boolean forfeit) {
+    return new PersonalizedTranslatable(
+            forfeit ? "command.forfeit.voted" : "command.forfeit.withdraw",
+            getForfeitStatusComponent())
+        .getPersonalizedText()
+        .color(ChatColor.GRAY);
+  }
+
+  private Component getForfeitBroadcast(MatchPlayer voted, boolean forfeit, boolean hasVoted) {
+    Component broadcast =
+        new PersonalizedTranslatable(
+                forfeit ? "forfeit.broadcast.vote" : "forfeit.broadcast.withdraw",
+                voted.getStyledName(NameStyle.COLOR),
+                getForfeitStatusComponent())
+            .getPersonalizedText()
+            .color(ChatColor.GRAY);
+
+    if (hasVoted) {
+      return broadcast;
+    } else {
+      return broadcast
+          .clickEvent(ClickEvent.Action.RUN_COMMAND, "/forfeit")
+          .hoverEvent(
+              HoverEvent.Action.SHOW_TEXT,
+              new PersonalizedTranslatable("forfeit.broadcast.hover")
+                  .getPersonalizedText()
+                  .color(ChatColor.GRAY)
+                  .render());
+    }
+  }
+}

--- a/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
+++ b/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
@@ -51,6 +51,10 @@ public class TimeLimitMatchModule extends MatchModule {
     return countdown;
   }
 
+  public boolean hasTimeLimit() {
+    return getCountdown() != null;
+  }
+
   public @Nullable Duration getFinalRemaining() {
     return this.countdown == null ? null : this.countdown.getRemaining();
   }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -117,3 +117,20 @@ sidebar:
   bottom: ""
   # If the sidebar message should overwrite lines in the sidebar when it is full
   overwrite: false
+
+forfeit:
+  # When forfeit is enabled players are able to use /forfeit to end the match.
+  # Will only end the match if every participant uses the /forfeit command.
+  enabled: true
+  
+  # Defines the maximum amount of players (per match), in which to allow a forfeit.
+  #
+  # Example: If max-players is at 25, matches which have 25 or less participants
+  # will be allowed to forfeit. Larger than 25 players and forfeit will disable.
+  #
+  # Note: set to 0 to disable this feature.
+  max-players: 10
+  
+  # When true, a broadcast will be sent to everyone after each /forfeit vote.
+  # If false feedback will only be sent to the player who used /forfeit.
+  broadcast-votes: true 


### PR DESCRIPTION
# Forfeit Command

## Background
The other day I witnessed a scenario in which having a /forfeit command could have been useful. The scenario in question involved players unable to finish a match due to an element being broken. Due to this unintentional error, players were confused and had to wait for a staff member to come online and end the match. Had a /forfeit command been available, they would have easily been able to solve this problem without intervention. 

## Overview
Forfeit as implemented  will allow for users to vote to end a match without completing the main objective. Also included are multiple config options to customize the functionality of a forfeit, such as whether the votes are broadcasted. Also restrictions are in place to prevent the command from being used in situations where it wouldn’t make sense, such as a match with no teams or a time limit. I did perform extensive testing and found no issues regarding the command. 

### Command
The command syntax is simply `/forfeit` 

Staff (players with `pgm.staff`), can use the `/forfeit -t` to toggle whether forfeit is enabled/disabled for the current match.

In order for the forfeit vote to go through, all activate participants must use the `/forfeit` command. This decision was made to make sure everyone is in agreement when choosing to end a match early. I would like to see a future update that includes options for a single team to forfeit, however this commit does not include that. 

### Config Options
As mentioned above, added to the config are a few options to customize the forfeit functionality. Most are self explanatory, however I would like to give some insight into the `max-players` option.

On more popular PGM servers, it may hinder rather than help the experience when a certain amount of players are online. Rather than just disabling the whole system, I’ve included the `max-players` option in order to limit using the command when the participant count is larger. Of course it can also be disabled as described in the config. 

In its current form, I feel `/forfeit` will benefit most during smaller matches of players. However, it may also come in handy on larger matches that come to a stalemate. 

### Screenshot
Below you can see what the feedback is when using the /forfeit command two times. Performing the command a second time will withdraw your vote. 
![Screen Shot 2020-01-10 at 1 05 31 AM](https://user-images.githubusercontent.com/3377659/72140407-90018480-3345-11ea-9d19-630187a24531.png)


### Name Note
Personally I had a difficult time finding the proper name for this feature. I felt that in the end forfeit fit most naturally with PGM’s game modes. However some alternatives that came into my mind earlier include surrender and abandon. If these or similar names are wanted as aliases just let me know. 

Signed-off-by: applenick <applenick@users.noreply.github.com>