### PR TITLE
Fix scores not resetting & add chance to pool command

### DIFF
--- a/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -74,7 +74,10 @@ public class MapPoll {
   }
 
   private double getWeight(PGMMap map) {
-    Double score = mapScores.get(map);
+    return getWeight(mapScores.get(map));
+  }
+
+  public static double getWeight(Double score) {
     if (score == null || score <= 0) return 0;
     return Math.max(Math.pow(score, 2), Double.MIN_VALUE);
   }

--- a/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.map.MapLibrary;
 import tc.oc.pgm.map.PGMMap;
 
@@ -87,6 +88,13 @@ public abstract class MapPool implements PGMMapOrder, Comparable<MapPool> {
    */
   @Override
   public void setNextMap(PGMMap map) {}
+
+  /**
+   * Called when this map pool is going to be switched out
+   *
+   * @param match The match that is currently ending
+   */
+  public void unloadPool(Match match) {};
 
   @Override
   public int compareTo(MapPool o) {

--- a/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -55,8 +55,7 @@ public class MapPoolManager implements PGMMapOrder {
             .filter(MapPool::isEnabled)
             .collect(Collectors.toList());
 
-    MapPool lastActiveMapPool = getMapPoolByName(mapPoolFileConfig.getString("last_active"));
-    setActiveMapPool(lastActiveMapPool);
+    activeMapPool = getMapPoolByName(mapPoolFileConfig.getString("last_active"));
   }
 
   public void saveMapPools() {
@@ -65,10 +64,6 @@ public class MapPoolManager implements PGMMapOrder {
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Could not save next map for future reference", e);
     }
-  }
-
-  private void setActiveMapPool(MapPool activeMapPool) {
-    this.activeMapPool = activeMapPool;
   }
 
   public MapPool getActiveMapPool() {
@@ -82,7 +77,8 @@ public class MapPoolManager implements PGMMapOrder {
   private void updateActiveMapPool(MapPool mapPool, Match match) {
     if (mapPool == activeMapPool) return;
 
-    setActiveMapPool(mapPool);
+    activeMapPool.unloadPool(match);
+    activeMapPool = mapPool;
 
     mapPoolFileConfig.set("last_active", activeMapPool.getName());
     saveMapPools();

--- a/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -41,6 +41,8 @@ public class VotingPool extends MapPool {
 
   /** Ticks scores for all maps, making them go slowly towards DEFAULT_WEIGHT. */
   private void tickScores(PGMMap currentMap) {
+    // If the current map isn't from this pool, ignore ticking
+    if (!mapScores.containsKey(currentMap)) return;
     mapScores.replaceAll(
         (mapScores, value) ->
             value > DEFAULT_WEIGHT
@@ -66,6 +68,11 @@ public class VotingPool extends MapPool {
   @Override
   public void setNextMap(PGMMap map) {
     currentPoll = null;
+  }
+
+  @Override
+  public void unloadPool(Match match) {
+    tickScores(match.getMap());
   }
 
   @Override


### PR DESCRIPTION
Voting pools wouldn't get the score for the ended match set to 0 if the dynamic map pool switched  to a different pool.

Also added a `-c` switch that calculates the chance of a map being the first option on the vote.
Calculating how likely it is to be on the vote as a whole, is rather complicated to calculate (would need to add up all possible n choices per voting option) and wouldn't yield more accurate results in real-world situations.