### PR TITLE
Patch union wrapped Cuboids in FiniteBlockRegion#fromWorld

### DIFF
--- a/src/main/java/tc/oc/pgm/regions/FiniteBlockRegion.java
+++ b/src/main/java/tc/oc/pgm/regions/FiniteBlockRegion.java
@@ -142,7 +142,13 @@ public class FiniteBlockRegion extends AbstractRegion {
     Bounds bounds = region.getBounds();
     PGMMap map = PGM.get().getMatchManager().getMatch(world).getMap();
 
-    if (region instanceof CuboidRegion
+    // TODO: Fix this, this is a hacky workaround to fix broken maps
+    boolean isCuboidUnionWrapped =
+        region instanceof Union
+            && ((Union) region).getRegions().length == 1
+            && ((Union) region).getRegions()[0] instanceof CuboidRegion;
+
+    if ((region instanceof CuboidRegion || isCuboidUnionWrapped)
         && map != null
         && map.getInfo().proto.isOlderThan(REGION_FIX_VERSION)) {
       // The loops below are incorrect, because they go one block over the max.


### PR DESCRIPTION
Signed-off-by: botinator <53882853+botinator@users.noreply.github.com>

Temporary fix for #225, it just allows the points to function normally and prevents any issues where old maps will not detect monument breaks and therefore get stuck on the current map. This is a hot fix and not a long term solution. 