### PR TITLE
Fix unions breaking 1.3.0 proto maps

### DIFF
--- a/src/main/java/tc/oc/pgm/regions/Complement.java
+++ b/src/main/java/tc/oc/pgm/regions/Complement.java
@@ -4,7 +4,7 @@ import org.bukkit.util.Vector;
 
 public class Complement extends AbstractRegion {
   private final Region original;
-  private final Union subtracted;
+  private final Region subtracted;
 
   public Complement(Region original, Region... subtracted) {
     this.original = original;

--- a/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -61,15 +61,11 @@ public abstract class RegionParser {
   public Region parseChildren(Element parent) throws InvalidXMLException {
     Attribute attrRegion = parent.getAttribute("region");
     Region reference = attrRegion == null ? null : this.parseReference(attrRegion);
-    Region body = this.parseUnion(parent);
+    List<Region> regions = this.parseSubRegions(parent);
 
-    if (reference == null) {
-      return body;
-    } else if (body == EmptyRegion.INSTANCE) {
-      return reference;
-    } else {
-      return new Union(reference, body);
-    }
+    if (reference != null) regions.add(reference);
+
+    return Union.of(regions.toArray(new Region[0]));
   }
 
   public Region[] parseSubRegionsArray(Element parent) throws InvalidXMLException {
@@ -296,12 +292,7 @@ public abstract class RegionParser {
 
   @MethodParser("union")
   public Region parseUnion(Element el) throws InvalidXMLException {
-    Region[] regions = this.parseSubRegionsArray(el);
-    if (regions.length < 1) {
-      return EmptyRegion.INSTANCE;
-    } else {
-      return new Union(regions);
-    }
+    return new Union(this.parseSubRegionsArray(el));
   }
 
   @MethodParser("intersect")

--- a/src/main/java/tc/oc/pgm/regions/Union.java
+++ b/src/main/java/tc/oc/pgm/regions/Union.java
@@ -9,8 +9,10 @@ public class Union extends AbstractRegion {
     this.regions = regions;
   }
 
-  public static Union of(Region... regions) {
-    return new Union(regions);
+  public static Region of(Region... regions) {
+    return regions.length == 0
+        ? EmptyRegion.INSTANCE
+        : regions.length == 1 ? regions[0] : new Union(regions);
   }
 
   public Region[] getRegions() {


### PR DESCRIPTION
Fixes #225 

When parsing arbitrary child regions, like on monuments or control points, pgm will only create a union if there are multiple child regions. This is the behaviour 1.12 PGM has.