### PR TITLE
Modernize the /match format, resolves Electroid#229

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -601,7 +601,8 @@ map.gamemode.long.arcade = Arcade
 map.gamemode.long.ffa = Free-for-all
 map.gamemode.long.mixed = Mixed
 
-command.match.matchInfo.title = Match Info
+# {0} = The current match number
+command.match.matchInfo.title = Match #{0}
 command.match.matchInfo.time = Time
 command.match.matchInfo.matchTime = Match Time
 command.match.matchInfo.goals = Goals

--- a/src/main/java/tc/oc/pgm/commands/MatchCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MatchCommands.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import tc.oc.pgm.AllTranslations;
 import tc.oc.pgm.api.match.Match;
@@ -24,7 +24,7 @@ import tc.oc.pgm.goals.ProximityGoal;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
-import tc.oc.util.StringUtils;
+import tc.oc.util.components.ComponentUtils;
 import tc.oc.util.components.PeriodFormats;
 import tc.oc.util.localization.Locales;
 
@@ -39,13 +39,13 @@ public class MatchCommands {
         match.getPhase() == MatchPhase.RUNNING || match.getPhase() == MatchPhase.FINISHED;
 
     sender.sendMessage(
-        StringUtils.dashedChatMessage(
+        ComponentUtils.horizontalLineHeading(
             ChatColor.YELLOW
-                + " "
                 + AllTranslations.get()
                     .translate("command.match.matchInfo.title", sender, match.getId()),
-            ChatColor.STRIKETHROUGH + "-",
-            ChatColor.WHITE.toString()));
+            ChatColor.WHITE,
+            ComponentUtils.MAX_CHAT_WIDTH));
+
     if (haveGameInfo) {
       // show match time
       sender.sendMessage(

--- a/src/main/java/tc/oc/pgm/commands/MatchCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MatchCommands.java
@@ -8,14 +8,19 @@ import com.google.common.collect.Multimap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import tc.oc.pgm.AllTranslations;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.ffa.FreeForAllMatchModule;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.GoalMatchModule;
+import tc.oc.pgm.goals.ProximityGoal;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
@@ -28,18 +33,19 @@ public class MatchCommands {
   @Command(
       aliases = {"matchinfo", "match"},
       desc = "Shows information about the current match")
-  public static void matchInfo(CommandSender sender, Match match) {
+  public static void matchInfo(CommandSender sender, MatchPlayer player, Match match) {
     // indicates whether we have game information from the match yet
     boolean haveGameInfo =
         match.getPhase() == MatchPhase.RUNNING || match.getPhase() == MatchPhase.FINISHED;
 
     sender.sendMessage(
         StringUtils.dashedChatMessage(
-            ChatColor.DARK_AQUA
+            ChatColor.YELLOW
                 + " "
-                + AllTranslations.get().translate("command.match.matchInfo.title", sender),
+                + AllTranslations.get()
+                    .translate("command.match.matchInfo.title", sender, match.getId()),
             ChatColor.STRIKETHROUGH + "-",
-            ChatColor.RED.toString()));
+            ChatColor.WHITE.toString()));
     if (haveGameInfo) {
       // show match time
       sender.sendMessage(
@@ -105,11 +111,14 @@ public class MatchCommands {
         Multimap<Team, String> teamGoalTexts = HashMultimap.create();
 
         for (Team team : tmm.getParticipatingTeams()) {
-          for (Goal goal : gmm.getGoals(team)) {
+          for (Goal<?> goal : gmm.getGoals(team)) {
             if (goal.isVisible()) {
-              teamGoalTexts.put(
-                  team,
-                  (goal.isCompleted(team) ? ChatColor.GREEN : ChatColor.DARK_RED) + goal.getName());
+              if (player != null) {
+                teamGoalTexts.put(
+                    team, renderGoal(goal, player.getCompetitor(), player.getParty()));
+              } else {
+                teamGoalTexts.put(team, renderGoal(goal, null, match.getDefaultParty()));
+              }
             }
           }
         }
@@ -140,5 +149,26 @@ public class MatchCommands {
         }
       }
     }
+  }
+
+  // Modified from SidebarMatchModule to make formatting easier
+  private static String renderGoal(
+      Goal<?> goal, @Nullable Competitor competitor, Party viewingParty) {
+    StringBuilder sb = new StringBuilder(" ");
+
+    sb.append(goal.renderSidebarStatusColor(competitor, viewingParty));
+    sb.append(goal.renderSidebarStatusText(competitor, viewingParty));
+
+    if (goal instanceof ProximityGoal) {
+      sb.append(" ");
+      // Show teams their own proximity on shared goals
+      sb.append(((ProximityGoal) goal).renderProximity(competitor, viewingParty));
+    }
+
+    sb.append(" ");
+    sb.append(goal.renderSidebarLabelColor(competitor, viewingParty));
+    sb.append(goal.renderSidebarLabelText(competitor, viewingParty));
+
+    return sb.toString();
   }
 }


### PR DESCRIPTION
Resolves #229 

I’ve included some screenshots comparing the old format first, then the new format.

Let me know if there are any changes you would like.

### Current /match formatting:
![Screen Shot 2020-01-15 at 6 15 43 PM](https://user-images.githubusercontent.com/3377659/72487535-2ceb7400-37c3-11ea-94c8-c49fe3fc49e3.png)


### New /match formatting:
![Screen Shot 2020-01-15 at 5 03 36 PM](https://user-images.githubusercontent.com/3377659/72487555-3ffe4400-37c3-11ea-9b4d-22cb5d189311.png)

### Additional screenshot:
![Screen Shot 2020-01-15 at 5 03 03 PM](https://user-images.githubusercontent.com/3377659/72487614-76d45a00-37c3-11ea-87b7-25d7a73d4944.png)



Signed-off-by: applenick <applenick@users.noreply.github.com>