### PR TITLE
Add a cooldown to /report, resolves Electroid#242

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -458,7 +458,7 @@ command.report.notify = {0} reported {1}: {2}
 command.report.acknowledge = The issue will be dealt with shortly.
 
 # {0} = amount of time
-command.report.cooldown = Please wait {0} before submitting another report
+command.cooldown = Please wait {0} before running that command again
 
 # {0} = team name
 ffa.join = You joined the match

--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -457,6 +457,9 @@ command.development.listErrors.noErrors = No errors!
 command.report.notify = {0} reported {1}: {2}
 command.report.acknowledge = The issue will be dealt with shortly.
 
+# {0} = amount of time
+command.report.cooldown = Please wait {0} before submitting another report
+
 # {0} = team name
 ffa.join = You joined the match
 team.join = You joined {0}

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -48,7 +48,7 @@ public class ModerationCommands {
         Duration timeSinceReport = Duration.between(lastReport, Instant.now());
         long secondsRemaining = REPORT_COOLDOWN_SECONDS - timeSinceReport.getSeconds();
         if (secondsRemaining > 0) {
-          Component secondsComponent = new PersonalizedText("" + secondsRemaining);
+          Component secondsComponent = new PersonalizedText(Long.toString(secondsRemaining));
           Component secondsLeftComponent =
               new PersonalizedTranslatable(
                       secondsRemaining != 1

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -29,10 +29,7 @@ public class ModerationCommands {
   private static final int REPORT_COOLDOWN_SECONDS = 15;
 
   private static final Cache<UUID, Instant> lastReportSent =
-      CacheBuilder.newBuilder()
-          .weakKeys()
-          .expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS)
-          .build();
+      CacheBuilder.newBuilder().expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS).build();
 
   @Command(
       aliases = {"report"},
@@ -55,7 +52,7 @@ public class ModerationCommands {
           throw new CommandException(
               AllTranslations.get()
                   .translate(
-                      "command.report.cooldown",
+                      "command.cooldown",
                       commandSender,
                       ChatColor.AQUA
                           + (secondsRemaining

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -17,7 +17,6 @@ import tc.oc.component.Component;
 import tc.oc.component.types.PersonalizedText;
 import tc.oc.component.types.PersonalizedTranslatable;
 import tc.oc.named.NameStyle;
-import tc.oc.pgm.AllTranslations;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.chat.Audience;
 import tc.oc.pgm.api.match.Match;
@@ -49,16 +48,15 @@ public class ModerationCommands {
         Duration timeSinceReport = Duration.between(lastReport, Instant.now());
         long secondsRemaining = REPORT_COOLDOWN_SECONDS - timeSinceReport.getSeconds();
         if (secondsRemaining > 0) {
-          throw new CommandException(
-              AllTranslations.get()
-                  .translate(
-                      "command.cooldown",
-                      commandSender,
-                      ChatColor.AQUA
-                          + (secondsRemaining
-                              + " second"
-                              + (secondsRemaining != 1 ? "s" : "")
-                              + ChatColor.RED)));
+          Component secondsLeft =
+              new PersonalizedText(
+                      secondsRemaining + " second" + (secondsRemaining != 1 ? "s" : ""))
+                  .color(ChatColor.AQUA);
+          commandSender.sendMessage(
+              new PersonalizedTranslatable("command.cooldown", secondsLeft)
+                  .getPersonalizedText()
+                  .color(ChatColor.RED));
+          return;
         }
       } else {
         // Player has no cooldown, so add one

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -3,9 +3,8 @@ package tc.oc.pgm.commands;
 import app.ashcon.intake.Command;
 import app.ashcon.intake.CommandException;
 import app.ashcon.intake.parametric.annotation.Text;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
@@ -29,17 +28,11 @@ public class ModerationCommands {
 
   private static final int REPORT_COOLDOWN_SECONDS = 15;
 
-  private static final LoadingCache<UUID, Instant> lastReportSent =
+  private static final Cache<UUID, Instant> lastReportSent =
       CacheBuilder.newBuilder()
           .weakKeys()
           .expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS)
-          .build(
-              new CacheLoader<UUID, Instant>() {
-                @Override
-                public Instant load(UUID uuid) throws Exception {
-                  return Instant.now();
-                }
-              });
+          .build();
 
   @Command(
       aliases = {"report"},


### PR DESCRIPTION
Resolves #242 

The changes were inspired by [here](https://github.com/OvercastNetwork/ProjectAres/blob/b883ef579938c49076379fa306592da847fc672f/Commons/bukkit/src/main/java/tc/oc/commons/bukkit/report/ReportCommands.java#L105) 

I did not want to deviate too far from what has been done in the past. The cooldown is implemented with a hard-coded 15 second cooldown, which I feel will be appropriate for most situations.

 If it is desired I can add a config option or adjust the hard-coded limit, just let me know.

~~Edit: Forgot to mention, I did not add a bypass for players with a specific permission. As I can’t really imagine any situation where one would want to bypass this check. Anyway, if that is desired I can happily add it too.~~ (Outdated)

Screenshot of formatting (what would happen if user spams the command several times):
![Screen Shot 2020-01-17 at 10 40 32 AM](https://user-images.githubusercontent.com/3377659/72637777-e3ac3900-3916-11ea-8a94-6926b390d8b0.png)
Signed-off-by: applenick <applenick@users.noreply.github.com>