### PR TITLE
Add soft dependency on ViaVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,6 @@
             <id>ashcon-app</id>
             <url>https://repo.ashcon.app/content/repositories/snapshots</url>
         </repository>
-        <repository>
-            <id>viaversion-repo</id>
-            <url>https://repo.viaversion.com</url>
-        </repository>
     </repositories>
     <distributionManagement>
         <repository>
@@ -81,11 +77,6 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.28.0</version>
-        </dependency>
-        <dependency>
-            <groupId>us.myles</groupId>
-            <artifactId>viaversion</artifactId>
-            <version>2.2.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
             <id>ashcon-app</id>
             <url>https://repo.ashcon.app/content/repositories/snapshots</url>
         </repository>
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
     </repositories>
     <distributionManagement>
         <repository>
@@ -77,6 +81,11 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.28.0</version>
+        </dependency>
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>2.2.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
             <id>ashcon-app</id>
             <url>https://repo.ashcon.app/content/repositories/snapshots</url>
         </repository>
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
     </repositories>
     <distributionManagement>
         <repository>
@@ -77,6 +81,12 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.28.0</version>
+        </dependency>
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>2.2.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -195,6 +195,22 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
   void applyKit(Kit kit, boolean force);
 
   /**
+   * Set the {@link MatchPlayer}'s client protocol version; useful if a plugin like ViaVersion
+   * overrides the protocol version returned by {@link
+   * net.minecraft.server.v1_8_R3.NetworkManager#protocolVersion}
+   *
+   * @param protocolVersion The protocol version
+   */
+  void setProtocolVersion(int protocolVersion);
+
+  /**
+   * Get the protocol version of the {@link MatchPlayer}'s client
+   *
+   * @return The protocol version of the {@link MatchPlayer}'s client
+   */
+  int getProtocolVersion();
+
+  /**
    * Get the {@link Settings} of the {@link MatchPlayer}.
    *
    * @return The cached {@link Settings}.

--- a/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -195,15 +195,6 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
   void applyKit(Kit kit, boolean force);
 
   /**
-   * Set the {@link MatchPlayer}'s client protocol version; useful if a plugin like ViaVersion
-   * overrides the protocol version returned by {@link
-   * net.minecraft.server.v1_8_R3.NetworkManager#protocolVersion}
-   *
-   * @param protocolVersion The protocol version
-   */
-  void setProtocolVersion(int protocolVersion);
-
-  /**
    * Get the protocol version of the {@link MatchPlayer}'s client
    *
    * @return The protocol version of the {@link MatchPlayer}'s client

--- a/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.listeners;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.UUID;
 import net.md_5.bungee.api.ChatColor;
@@ -45,7 +45,6 @@ import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.gamerules.GameRule;
 import tc.oc.pgm.gamerules.GameRulesModule;
 import tc.oc.pgm.modules.TimeLockModule;
-import tc.oc.util.ViaUtils;
 
 public class PGMListener implements Listener {
   private final Plugin parent;
@@ -72,7 +71,6 @@ public class PGMListener implements Listener {
 
   @EventHandler(priority = EventPriority.LOW)
   public void addPlayerOnJoin(final PlayerJoinEvent event) {
-    System.out.println(ViaUtils.getProtocolVersion(event.getPlayer())); // XXX REMOVE THIS
     if (this.mm.getMatch(event.getWorld()) == null) {
       event
           .getPlayer()

--- a/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -45,6 +45,7 @@ import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.gamerules.GameRule;
 import tc.oc.pgm.gamerules.GameRulesModule;
 import tc.oc.pgm.modules.TimeLockModule;
+import tc.oc.util.ViaUtils;
 
 public class PGMListener implements Listener {
   private final Plugin parent;
@@ -71,6 +72,7 @@ public class PGMListener implements Listener {
 
   @EventHandler(priority = EventPriority.LOW)
   public void addPlayerOnJoin(final PlayerJoinEvent event) {
+    System.out.println(ViaUtils.getProtocolVersion(event.getPlayer())); // XXX REMOVE THIS
     if (this.mm.getMatch(event.getWorld()) == null) {
       event
           .getPlayer()

--- a/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.listeners;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 import java.util.UUID;
 import net.md_5.bungee.api.ChatColor;

--- a/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.bukkit.GameMode;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -78,9 +77,7 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
     this.frozen = new AtomicBoolean(false);
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
-    this.protocolVersion =
-        new AtomicInteger(
-            ((CraftPlayer) player).getHandle().playerConnection.networkManager.protocolVersion);
+    this.protocolVersion = new AtomicInteger(NMSHacks.getProtocolVersion(player));
   }
 
   @Override

--- a/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -17,6 +18,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.bukkit.GameMode;
 import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -62,6 +64,7 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
   private final AtomicBoolean frozen;
   private final AtomicBoolean dead;
   private final AtomicBoolean visible;
+  private final AtomicInteger protocolVersion;
 
   public MatchPlayerImpl(Match match, Player player) {
     this.logger =
@@ -75,6 +78,9 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
     this.frozen = new AtomicBoolean(false);
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
+    this.protocolVersion =
+        new AtomicInteger(
+            ((CraftPlayer) player).getHandle().playerConnection.networkManager.protocolVersion);
   }
 
   @Override
@@ -327,6 +333,16 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
                 }
               }
             });
+  }
+
+  @Override
+  public void setProtocolVersion(int protocolVersion) {
+    this.protocolVersion.set(protocolVersion);
+  }
+
+  @Override
+  public int getProtocolVersion() {
+    return protocolVersion.get();
   }
 
   @Override

--- a/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -46,6 +46,7 @@ import tc.oc.pgm.filters.query.IPlayerQuery;
 import tc.oc.pgm.filters.query.PlayerQuery;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.kits.WalkSpeedKit;
+import tc.oc.util.ViaUtils;
 import tc.oc.util.logging.ClassLogger;
 import tc.oc.world.DeathOverride;
 import tc.oc.world.NMSHacks;
@@ -77,7 +78,7 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
     this.frozen = new AtomicBoolean(false);
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
-    this.protocolVersion = new AtomicInteger(NMSHacks.getProtocolVersion(player));
+    this.protocolVersion = new AtomicInteger(ViaUtils.getProtocolVersion(player));
   }
 
   @Override
@@ -330,11 +331,6 @@ public class MatchPlayerImpl implements MatchPlayer, MultiAudience, Comparable<M
                 }
               }
             });
-  }
-
-  @Override
-  public void setProtocolVersion(int protocolVersion) {
-    this.protocolVersion.set(protocolVersion);
   }
 
   @Override

--- a/src/main/java/tc/oc/util/ViaUtils.java
+++ b/src/main/java/tc/oc/util/ViaUtils.java
@@ -1,0 +1,16 @@
+package tc.oc.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import tc.oc.world.NMSHacks;
+import us.myles.ViaVersion.api.Via;
+
+public class ViaUtils {
+  public static boolean enabled() {
+    return Bukkit.getServer().getPluginManager().getPlugin("ViaVersion") != null;
+  }
+
+  public static int getProtocolVersion(Player player) {
+    return enabled() ? Via.getAPI().getPlayerVersion(player) : NMSHacks.getProtocolVersion(player);
+  }
+}

--- a/src/main/java/tc/oc/util/ViaUtils.java
+++ b/src/main/java/tc/oc/util/ViaUtils.java
@@ -1,23 +1,16 @@
 package tc.oc.util;
 
-import java.lang.reflect.Method;
-import java.util.logging.Level;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.PGM;
 import tc.oc.world.NMSHacks;
+import us.myles.ViaVersion.api.Via;
 
 public class ViaUtils {
   private static boolean enabled;
-  private static Object viaAPI;
-  private static Method getPlayerVersion;
 
   static {
     try {
-      viaAPI = Class.forName("us.myles.ViaVersion.api.Via").getMethod("getAPI").invoke(null);
-      getPlayerVersion =
-          Class.forName("us.myles.ViaVersion.api.ViaAPI")
-              .getMethod("getPlayerVersion", Object.class);
-      enabled = true;
+      enabled = Class.forName("us.myles.ViaVersion.api.Via") != null;
     } catch (Exception e) {
       PGM.get().getLogger().warning("ViaVersion is not installed");
       enabled = false;
@@ -33,18 +26,10 @@ public class ViaUtils {
    *     href="https://wiki.vg/Protocol_version_numbers">https://wiki.vg/Protocol_version_numbers</a>
    */
   public static int getProtocolVersion(Player player) {
-    int version = NMSHacks.getProtocolVersion(player);
     if (enabled()) {
-      try {
-        return (int) getPlayerVersion.invoke(viaAPI, player);
-      } catch (Exception e) {
-        PGM.get()
-            .getLogger()
-            .log(Level.WARNING, "Could not get player's protocol version from ViaVersion", e);
-        return version;
-      }
+      return Via.getAPI().getPlayerVersion(player);
     } else {
-      return version;
+      return NMSHacks.getProtocolVersion(player);
     }
   }
 }

--- a/src/main/java/tc/oc/util/ViaUtils.java
+++ b/src/main/java/tc/oc/util/ViaUtils.java
@@ -1,6 +1,7 @@
 package tc.oc.util;
 
 import java.lang.reflect.Method;
+import java.util.logging.Level;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.PGM;
 import tc.oc.world.NMSHacks;
@@ -19,7 +20,6 @@ public class ViaUtils {
       enabled = true;
     } catch (Exception e) {
       PGM.get().getLogger().warning("ViaVersion is not installed");
-      e.printStackTrace();
       enabled = false;
     }
   }
@@ -38,7 +38,9 @@ public class ViaUtils {
       try {
         return (int) getPlayerVersion.invoke(viaAPI, player);
       } catch (Exception e) {
-        e.printStackTrace();
+        PGM.get()
+            .getLogger()
+            .log(Level.WARNING, "Could not get player's protocol version from ViaVersion", e);
         return version;
       }
     } else {

--- a/src/main/java/tc/oc/util/ViaUtils.java
+++ b/src/main/java/tc/oc/util/ViaUtils.java
@@ -1,24 +1,23 @@
 package tc.oc.util;
 
 import org.bukkit.entity.Player;
-import tc.oc.pgm.api.PGM;
 import tc.oc.world.NMSHacks;
 import us.myles.ViaVersion.api.Via;
 
 public class ViaUtils {
-  private static boolean enabled;
+  private static final boolean ENABLED;
 
   static {
+    boolean viaLoaded = false;
     try {
-      enabled = Class.forName("us.myles.ViaVersion.api.Via") != null;
-    } catch (Exception e) {
-      PGM.get().getLogger().warning("ViaVersion is not installed");
-      enabled = false;
+      viaLoaded = Class.forName("us.myles.ViaVersion.api.Via") != null;
+    } catch (ClassNotFoundException ignored) {
     }
+    ENABLED = viaLoaded;
   }
 
   public static boolean enabled() {
-    return enabled;
+    return ENABLED;
   }
 
   /**

--- a/src/main/java/tc/oc/util/ViaUtils.java
+++ b/src/main/java/tc/oc/util/ViaUtils.java
@@ -1,16 +1,48 @@
 package tc.oc.util;
 
-import org.bukkit.Bukkit;
+import java.lang.reflect.Method;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.api.PGM;
 import tc.oc.world.NMSHacks;
-import us.myles.ViaVersion.api.Via;
 
 public class ViaUtils {
-  public static boolean enabled() {
-    return Bukkit.getServer().getPluginManager().getPlugin("ViaVersion") != null;
+  private static boolean enabled;
+  private static Object viaAPI;
+  private static Method getPlayerVersion;
+
+  static {
+    try {
+      viaAPI = Class.forName("us.myles.ViaVersion.api.Via").getMethod("getAPI").invoke(null);
+      getPlayerVersion =
+          Class.forName("us.myles.ViaVersion.api.ViaAPI")
+              .getMethod("getPlayerVersion", Object.class);
+      enabled = true;
+    } catch (Exception e) {
+      PGM.get().getLogger().warning("ViaVersion is not installed");
+      e.printStackTrace();
+      enabled = false;
+    }
   }
 
+  public static boolean enabled() {
+    return enabled;
+  }
+
+  /**
+   * @see <a
+   *     href="https://wiki.vg/Protocol_version_numbers">https://wiki.vg/Protocol_version_numbers</a>
+   */
   public static int getProtocolVersion(Player player) {
-    return enabled() ? Via.getAPI().getPlayerVersion(player) : NMSHacks.getProtocolVersion(player);
+    int version = NMSHacks.getProtocolVersion(player);
+    if (enabled()) {
+      try {
+        return (int) getPlayerVersion.invoke(viaAPI, player);
+      } catch (Exception e) {
+        e.printStackTrace();
+        return version;
+      }
+    } else {
+      return version;
+    }
   }
 }

--- a/src/main/java/tc/oc/world/NMSHacks.java
+++ b/src/main/java/tc/oc/world/NMSHacks.java
@@ -1026,4 +1026,8 @@ public interface NMSHacks {
   static void openBook(org.bukkit.inventory.ItemStack book, Player player) {
     ((CraftPlayer) player).getHandle().openBook(CraftItemStack.asNMSCopy(book));
   }
+
+  static int getProtocolVersion(Player player) {
+    return ((CraftPlayer) player).getHandle().playerConnection.networkManager.protocolVersion;
+  }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: PGM
 prefix: PGM
 main: tc.oc.pgm.PGMImpl
 version: ${project.version}-${git.commit.id.abbrev}
+softdepend: [ViaVersion]


### PR DESCRIPTION
Signed-off-by: Meeples10 <8867705+Meeples10@users.noreply.github.com>

If a ViaVersion is installed on the server, the usual way of getting a player's client protocol version always returns `47`. This change ~~would allow an external plugin to set the player's protocol version to the correct value by retrieving it from ViaVersion (see [§Get the players protocol version](https://docs.viaversion.com/display/VIAVERSION/Basic+API+usage) in the ViaVersion docs), which in turn~~ would allow PGM to behave differently for 1.7, 1.8, 1.15, etc. players. This could be used to fix #16.