### PR TITLE
Make commands using duration read config

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/provider/DurationProvider.java
+++ b/src/main/java/tc/oc/pgm/commands/provider/DurationProvider.java
@@ -27,6 +27,6 @@ public class DurationProvider implements BukkitProvider<Duration> {
           .toStandardDuration()
           .toDuration();
     }
-    return Duration.ZERO;
+    return Duration.standardSeconds(30L);
   }
 }

--- a/src/main/java/tc/oc/pgm/commands/provider/DurationProvider.java
+++ b/src/main/java/tc/oc/pgm/commands/provider/DurationProvider.java
@@ -27,6 +27,6 @@ public class DurationProvider implements BukkitProvider<Duration> {
           .toStandardDuration()
           .toDuration();
     }
-    return Duration.standardSeconds(30L);
+    return null;
   }
 }


### PR DESCRIPTION
My earlier "fix" only made it so all duration commands had 30 sec as a default. This didn't work with commands like start that has two values:
/start <countdown> <huddle>

Instead you want the commands using the default time specified in the config.yml, that should be fixed in this fix.

Signed-off-by: Simon <simonmr60@gmail.com>