### PR TITLE
Register ObserverToolsMatchModule

### DIFF
--- a/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/src/main/java/tc/oc/pgm/api/Modules.java
@@ -83,6 +83,7 @@ import tc.oc.pgm.modules.SoundsMatchModule;
 import tc.oc.pgm.modules.TimeLockModule;
 import tc.oc.pgm.modules.ToolRepairMatchModule;
 import tc.oc.pgm.modules.ToolRepairModule;
+import tc.oc.pgm.observers.ObserverToolsMatchModule;
 import tc.oc.pgm.picker.PickerMatchModule;
 import tc.oc.pgm.portals.PortalMatchModule;
 import tc.oc.pgm.portals.PortalModule;
@@ -153,6 +154,7 @@ public interface Modules {
     register(DoubleJumpMatchModule.class, DoubleJumpMatchModule::new);
     register(ArrowRemovalMatchModule.class, ArrowRemovalMatchModule::new);
     register(SoundsMatchModule.class, new SoundsMatchModule.Factory());
+    register(ObserverToolsMatchModule.class, new ObserverToolsMatchModule.Factory());
 
     // MatchModules that require other dependencies
     register(GoalMatchModule.class, new GoalMatchModule.Factory());


### PR DESCRIPTION
In a follow-up to #260, I noticed that functionality was not working. After inspection it seems that with the recent refactor by @Electroid, the ObserverToolsMatchModule was not registered in the new system. This fixes that problem and from my testing the Observer Tools function correctly with this fix.

Signed-off-by: applenick <applenick@users.noreply.github.com>