### PR TITLE
Fix 'You joined Observers' message after event cancellation, resolves #282

### DIFF
--- a/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -172,7 +172,6 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
     }
 
     Party observers = match.getDefaultParty();
-    leaving.sendMessage(new PersonalizedTranslatable("team.join", observers.getComponentName()));
     return match.setParty(leaving, observers);
   }
 

--- a/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -21,7 +21,6 @@ import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.match.factory.MatchModuleFactory;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.api.party.Competitor;
-import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.match.ObservingParty;
@@ -171,8 +170,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
       return false;
     }
 
-    Party observers = match.getDefaultParty();
-    return match.setParty(leaving, observers);
+    return match.setParty(leaving, match.getDefaultParty());
   }
 
   public QueuedParticipants getQueuedParticipants() {

--- a/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -634,7 +634,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPartyChange(PlayerPartyChangeEvent event) {
-    if (event.getNewParty() instanceof Team) {
+    if (event.getOldParty() != null && event.getNewParty() != null) {
       event
           .getPlayer()
           .sendMessage(

--- a/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -36,6 +36,7 @@ import tc.oc.pgm.join.JoinHandler;
 import tc.oc.pgm.join.JoinMatchModule;
 import tc.oc.pgm.join.JoinResult;
 import tc.oc.pgm.join.QueuedParticipants;
+import tc.oc.pgm.match.Observers;
 import tc.oc.pgm.start.StartMatchModule;
 import tc.oc.pgm.start.UnreadyReason;
 import tc.oc.pgm.teams.events.TeamResizeEvent;
@@ -634,7 +635,8 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPartyChange(PlayerPartyChangeEvent event) {
-    if (event.getOldParty() != null && event.getNewParty() != null) {
+    if (event.getNewParty() instanceof Team
+        || (event.getNewParty() instanceof Observers && event.getOldParty() != null)) {
       event
           .getPlayer()
           .sendMessage(


### PR DESCRIPTION
Did not intend to close the previous pull request. @Electroid is this a suitable fix, or should I change how the event is fired/handled anyway?

Signed-off-by: Meeples10 <8867705+Meeples10@users.noreply.github.com>