### PR TITLE
Quick-fix: Update visibility setting for Observer Tools

### DIFF
--- a/src/main/java/tc/oc/pgm/observers/tools/VisibilityTool.java
+++ b/src/main/java/tc/oc/pgm/observers/tools/VisibilityTool.java
@@ -60,5 +60,6 @@ public class VisibilityTool implements InventoryMenuItem {
   public void toggleObserverVisibility(MatchPlayer player) {
     Settings setting = player.getSettings();
     setting.toggleValue(SettingKey.OBSERVERS);
+    SettingKey.OBSERVERS.update(player);
   }
 }


### PR DESCRIPTION
Now that OCC has updated PGM to the latest version, I was able to test the tools with multiple players online. I had forgotten to call an update of the observer visibility setting when toggling from the menu. So this fixes that 🎉 

Signed-off-by: applenick <applenick@users.noreply.github.com>