### PR TITLE
Add reply as alias

### DIFF
--- a/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -148,7 +148,7 @@ public class ChatDispatcher implements Listener {
   }
 
   @Command(
-      aliases = {"r"},
+      aliases = {"reply", "r"},
       desc = "Reply to a direct message",
       usage = "[message]")
   public void sendReply(Match match, Audience audience, MatchPlayer sender, @Text String message) {


### PR DESCRIPTION
Signed-off-by: Patrick Rogers <cowinkkeydinkinc@gmail.com>

This adds `/reply` as an alias to `/r` to make it more easier for newer players to discover