### PR TITLE
Standardize wool names

### DIFF
--- a/src/main/java/tc/oc/pgm/listeners/FormattingListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/FormattingListener.java
@@ -15,7 +15,6 @@ import tc.oc.pgm.destroyable.DestroyableContribution;
 import tc.oc.pgm.destroyable.DestroyableDestroyedEvent;
 import tc.oc.pgm.util.TranslationUtils;
 import tc.oc.pgm.wool.PlayerWoolPlaceEvent;
-import tc.oc.server.BukkitUtils;
 import tc.oc.util.components.Components;
 
 public class FormattingListener implements Listener {
@@ -28,7 +27,7 @@ public class FormattingListener implements Listener {
               new PersonalizedTranslatable(
                   "match.complete.wool",
                   event.getPlayer().getStyledName(NameStyle.COLOR),
-                  BukkitUtils.woolName(event.getWool().getDyeColor()),
+                  event.getWool().getComponentName(),
                   event.getPlayer().getParty().getComponentName()));
     }
   }

--- a/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
+++ b/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
@@ -38,7 +38,6 @@ import tc.oc.pgm.goals.Contribution;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.teams.Team;
-import tc.oc.server.BukkitUtils;
 
 @ListenerScope(MatchScope.RUNNING)
 public class WoolMatchModule implements MatchModule, Listener {
@@ -182,7 +181,7 @@ public class WoolMatchModule implements MatchModule, Listener {
 
     ParticipantState player = ParticipantBlockTransformEvent.getPlayerState(event);
     if (player != null) { // wool can only be placed by a player
-      Component woolName = BukkitUtils.woolName(wool.getDyeColor());
+      Component woolName = wool.getComponentName();
       if (!isValidWool(wool.getDyeColor(), event.getNewState())) {
         player.sendWarning(new PersonalizedTranslatable("match.wool.placeWrong", woolName), true);
       } else if (wool.getOwner() != player.getParty()) {
@@ -224,7 +223,7 @@ public class WoolMatchModule implements MatchModule, Listener {
                           .translate(
                               "match.wool.craftDisabled",
                               playerHolder.getBukkit(),
-                              BukkitUtils.woolMessage(wool.getDyeColor())));
+                              wool.getComponentName()));
               event.getInventory().setResult(null);
             }
           }

--- a/src/main/java/tc/oc/server/BukkitUtils.java
+++ b/src/main/java/tc/oc/server/BukkitUtils.java
@@ -12,9 +12,6 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffectType;
-import tc.oc.component.Component;
-import tc.oc.component.types.PersonalizedText;
-import tc.oc.util.components.ComponentUtils;
 
 public interface BukkitUtils {
 
@@ -34,16 +31,6 @@ public interface BukkitUtils {
     }
 
     return result;
-  }
-
-  static String woolMessage(DyeColor color) {
-    return dyeColorToChatColor(color) + color.toString().replace("_", " ") + " WOOL";
-  }
-
-  static Component woolName(DyeColor color) {
-    return new PersonalizedText(
-        color.toString().replace("_", " ") + " WOOL",
-        ComponentUtils.convert(dyeColorToChatColor(color)));
   }
 
   static ItemStack generateBook(String title, String author, List<String> pages) {


### PR DESCRIPTION
Moves every wool message to use the goal component name instead of the name based on color