### PR TITLE
Use null-safe tracking owner

### DIFF
--- a/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
@@ -75,7 +75,7 @@ public class AntiGriefListener implements Listener {
     }
 
     // check owner
-    MatchPlayer owner = this.mm.getPlayer(Trackers.getOwnerSafely(entity));
+    MatchPlayer owner = this.mm.getPlayer(Trackers.getOwner(entity));
     if (owner == null
         || (owner != clicker && owner.getParty() == clicker.getParty())) { // cannot defuse own TNT
       // defuse TNT
@@ -143,7 +143,7 @@ public class AntiGriefListener implements Listener {
       if (origin.distanceSquared(ent.getLocation()) > radiusSq) continue;
 
       if (ent instanceof TNTPrimed) {
-        ParticipantState player = Trackers.getOwnerSafely(ent);
+        ParticipantState player = Trackers.getOwner(ent);
 
         if (player != null) {
           owners.add(player);

--- a/src/main/java/tc/oc/pgm/listeners/LongRangeTNTListener.java
+++ b/src/main/java/tc/oc/pgm/listeners/LongRangeTNTListener.java
@@ -117,7 +117,7 @@ public class LongRangeTNTListener implements Listener {
     }
 
     public boolean show(TNT tnt) {
-      ParticipantState owner = Trackers.getOwnerSafely(tnt.entity);
+      ParticipantState owner = Trackers.getOwner(tnt.entity);
       boolean owned = owner != null && owner.getId().equals(this.player.getUniqueId());
       Slot slot = null;
 

--- a/src/main/java/tc/oc/pgm/tracker/Trackers.java
+++ b/src/main/java/tc/oc/pgm/tracker/Trackers.java
@@ -13,29 +13,17 @@ import tc.oc.pgm.tracker.damage.RangedInfo;
 public final class Trackers {
   private Trackers() {}
 
-  static TrackerMatchModule needModule(World world) {
-    return PGM.get().getMatchManager().getMatch(world).needModule(TrackerMatchModule.class);
-  }
-
   static @Nullable TrackerMatchModule getModule(World world) {
     Match match = PGM.get().getMatchManager().getMatch(world);
     return match == null ? null : match.getModule(TrackerMatchModule.class);
   }
 
   public static @Nullable ParticipantState getOwner(Entity entity) {
-    return needModule(entity.getWorld()).getEntityTracker().getOwner(entity);
-  }
-
-  public static @Nullable ParticipantState getOwnerSafely(Entity entity) {
     TrackerMatchModule tmm = getModule(entity.getWorld());
     return tmm == null ? null : tmm.getEntityTracker().getOwner(entity);
   }
 
   public static @Nullable ParticipantState getOwner(Block block) {
-    return needModule(block.getWorld()).getBlockTracker().getOwner(block);
-  }
-
-  public static @Nullable ParticipantState getOwnerSafely(Block block) {
     TrackerMatchModule tmm = getModule(block.getWorld());
     return tmm == null ? null : tmm.getBlockTracker().getOwner(block);
   }


### PR DESCRIPTION
When a match has ended and the match has cycled, lava may keep flowing on the world but no match exists. This can lead to errors when trying to getOwner for a block transform event because the TrackerMatchModule is no longer loaded.
A getOwnerSafely method already existed, but was unused or underused, i made that treatment the default since the owner of a block is never required and always nullable either way.