### PR TITLE
Add admin chat symbol and more sounds

### DIFF
--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -19,8 +19,11 @@ import tc.oc.component.types.PersonalizedTranslatable;
 import tc.oc.named.NameStyle;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.chat.Audience;
+import tc.oc.pgm.api.chat.Sound;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.events.PlayerReportEvent;
 
 public class ModerationCommands {
@@ -29,6 +32,8 @@ public class ModerationCommands {
 
   private static final Cache<UUID, Instant> LAST_REPORT_SENT =
       CacheBuilder.newBuilder().expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS).build();
+
+  private static final Sound REPORT_NOTIFY_SOUND = new Sound("random.pop", 1f, 1.2f);
 
   @Command(
       aliases = {"report"},
@@ -105,7 +110,14 @@ public class ModerationCommands {
 
     match.getPlayers().stream()
         .filter(viewer -> viewer.getBukkit().hasPermission(Permissions.ADMINCHAT))
-        .forEach(viewer -> viewer.sendMessage(prefixedComponent));
+        .forEach(
+            viewer -> {
+              // Play sound for viewers of reports
+              if (viewer.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ON)) {
+                viewer.playSound(REPORT_NOTIFY_SOUND);
+              }
+              viewer.sendMessage(prefixedComponent);
+            });
     Audience.get(Bukkit.getConsoleSender()).sendMessage(component);
   }
 }


### PR DESCRIPTION
# Add admin chat symbol and more sounds

### Admin Chat Symbol
Earlier today there was a suggestion by @Brottweiler to add `$` as a symbol shortcut for sending a message in the admin chat. I don’t believe there is any harm in having this as a shortcut, and with some testing I found it really is easy to use 😄 

![screenshot](https://user-images.githubusercontent.com/3377659/74125625-ab50f100-4b8a-11ea-9c7a-b1e694eddd90.gif)


### Sounds
Also added are two new sound effects (if sounds are enabled), both staff specific but should be a nice QOL feature to improve the experience. First, utilizing the same sound as private messages, will be when an admin chat message is received. Personally I am a fan of chat sounds, and feel they help to make identifying important information easier. Adding onto that is a sound that will play when a report is received, basically the same reason as the admin chat one.

### Notes:
I understand not all staff member may enjoy having every single admin chat message play a sound, however there is the sound setting so that should suffice. In addition to that, I'm now thinking it may be better to have  a different sound than the DM one, so if there is feedback regarding that let me know. 

Signed-off-by: applenick <applenick@users.noreply.github.com>