### PR TITLE
Add /staff command

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -893,3 +893,8 @@ observer.tools.flyspeed.hyperspeed = Hyperspeed
 
 observer.tools.visibility.shown = Shown
 observer.tools.visibility.hidden = Hidden
+
+# {0} = Number of online staff
+# {1} = List of staff players
+moderation.staff.name = Online Staff ({0}): {1}
+moderation.staff.empty = No staff online :(

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -7,8 +7,10 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -25,6 +27,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.events.PlayerReportEvent;
+import tc.oc.util.components.Components;
 
 public class ModerationCommands {
 
@@ -119,5 +122,38 @@ public class ModerationCommands {
               viewer.sendMessage(prefixedComponent);
             });
     Audience.get(Bukkit.getConsoleSender()).sendMessage(component);
+  }
+
+  @Command(
+      aliases = {"staff", "mods", "admins"},
+      desc = "List the online staff members")
+  public void staff(CommandSender sender, Match match) {
+    // List of online staff
+    List<Component> onlineStaff =
+        match.getPlayers().stream()
+            .filter(player -> player.getBukkit().hasPermission(Permissions.STAFF))
+            .map(player -> player.getStyledName(NameStyle.FANCY))
+            .collect(Collectors.toList());
+
+    // FORMAT: Online Staff ({count}): {names}
+    Component staffCount =
+        new PersonalizedText(Integer.toString(onlineStaff.size()))
+            .color(onlineStaff.size() >= 1 ? ChatColor.AQUA : ChatColor.RED);
+
+    Component content =
+        onlineStaff.isEmpty()
+            ? new PersonalizedTranslatable("moderation.staff.empty")
+                .getPersonalizedText()
+                .color(ChatColor.RED)
+            : new Component(
+                Components.join(new PersonalizedText(", ").color(ChatColor.GRAY), onlineStaff));
+
+    Component staff =
+        new PersonalizedTranslatable("moderation.staff.name", staffCount, content)
+            .getPersonalizedText()
+            .color(ChatColor.GRAY);
+
+    // Send message
+    sender.sendMessage(staff);
   }
 }


### PR DESCRIPTION
# Add /staff command

This was extracted from the #300 PR, adjusted with suggestions made by @Pablete1234. As this technically was the only command not related to actual punishments, it will most likely be within scope of PGM as it utilizes the `pgm.staff` permission. If not 🤷‍♂ , however I’m sure any server running PGM would find this command useful.

Formatting:
When no staff are online.
![staff-offline](https://user-images.githubusercontent.com/3377659/74384498-3d811100-4da6-11ea-853e-c7828b0221ab.png)

When staff are online, they will be listed along with the count
![staff-online](https://user-images.githubusercontent.com/3377659/74384520-4376f200-4da6-11ea-9216-6b69d8a99b22.png)


Signed-off-by: applenick <applenick@users.noreply.github.com>