### PR TITLE
WIP: Add moderation commands

### DIFF
--- a/core/src/main/java/tc/oc/pgm/Config.java
+++ b/core/src/main/java/tc/oc/pgm/Config.java
@@ -453,4 +453,29 @@ public class Config {
       return getConfiguration().getBoolean("sidebar.overwrite", false);
     }
   }
+
+  public static class Moderation {
+
+    public static boolean isRuleLinkVisible() {
+      return getRulesLink().length() > 0;
+    }
+
+    public static String getRulesLink() {
+      return getConfiguration().getString("moderation.rules-link", "");
+    }
+
+    public static String getServerName() {
+      return ChatColor.translateAlternateColorCodes(
+          '&', getConfiguration().getString("moderation.server-name", ""));
+    }
+
+    public static String getAppealMessage() {
+      return ChatColor.translateAlternateColorCodes(
+          '&', getConfiguration().getString("moderation.appeal-msg", ""));
+    }
+
+    public static boolean isAppealVisible() {
+      return getAppealMessage().length() > 0;
+    }
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -52,7 +52,6 @@ import tc.oc.pgm.commands.MapCommands;
 import tc.oc.pgm.commands.MapPoolCommands;
 import tc.oc.pgm.commands.MatchCommands;
 import tc.oc.pgm.commands.ModeCommands;
-import tc.oc.pgm.commands.ModerationCommands;
 import tc.oc.pgm.commands.ObserverCommands;
 import tc.oc.pgm.commands.SettingCommands;
 import tc.oc.pgm.commands.StartCommands;
@@ -66,6 +65,8 @@ import tc.oc.pgm.commands.provider.MatchProvider;
 import tc.oc.pgm.commands.provider.SettingKeyProvider;
 import tc.oc.pgm.commands.provider.TeamMatchModuleProvider;
 import tc.oc.pgm.commands.provider.VectorProvider;
+import tc.oc.pgm.community.commands.ModerationCommands;
+import tc.oc.pgm.community.commands.ReportCommands;
 import tc.oc.pgm.db.DatastoreCacheImpl;
 import tc.oc.pgm.db.DatastoreImpl;
 import tc.oc.pgm.events.ConfigLoadEvent;
@@ -317,9 +318,12 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     node.registerNode("mode", "modes").registerCommands(new ModeCommands());
     node.registerCommands(new TimeLimitCommands());
     node.registerCommands(new SettingCommands());
-    node.registerCommands(new ModerationCommands());
     node.registerCommands(new ObserverCommands());
     node.registerCommands(new MapPoolCommands());
+
+    // TODO: Community commands
+    node.registerCommands(new ModerationCommands(chat));
+    node.registerCommands(new ReportCommands());
 
     new BukkitIntake(this, graph).register();
   }

--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -30,6 +30,10 @@ public interface Permissions {
   String DEBUG = ROOT + ".debug"; // Errors from map loading and debug commands
   String STAFF = ROOT + ".staff"; // Considered apart of the staff team
   String RELOAD = ROOT + ".reload"; // Reload the PGM configuration
+  String KICK = ROOT + ".kick"; // Access to the /kick command
+  String WARN = ROOT + ".warn"; // Access to the /warn command
+  String MUTE = ROOT + ".mute"; // Access to the /mute command
+  String BAN = ROOT + ".ban"; // Access to the /ban command
 
   // Role-specific permission nodes
   Permission DEFAULT =
@@ -62,6 +66,10 @@ public interface Permissions {
               .put(JOIN_FORCE, true)
               .put(DEFUSE, true)
               .put(STAFF, true)
+              .put(KICK, true)
+              .put(WARN, true)
+              .put(MUTE, true)
+              .put(BAN, true)
               .build());
 
   Permission DEVELOPER =

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -1,0 +1,495 @@
+package tc.oc.pgm.community.commands;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.CommandException;
+import app.ashcon.intake.parametric.annotation.Switch;
+import app.ashcon.intake.parametric.annotation.Text;
+import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.BanList;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.pgm.Config;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.chat.Sound;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchManager;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.community.events.PlayerPunishmentEvent;
+import tc.oc.pgm.listeners.ChatDispatcher;
+import tc.oc.util.bukkit.component.Component;
+import tc.oc.util.bukkit.component.ComponentRenderers;
+import tc.oc.util.bukkit.component.ComponentUtils;
+import tc.oc.util.bukkit.component.Components;
+import tc.oc.util.bukkit.component.PeriodFormats;
+import tc.oc.util.bukkit.component.types.PersonalizedText;
+import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
+import tc.oc.util.bukkit.named.NameStyle;
+
+public class ModerationCommands {
+
+  private static final Sound WARN_SOUND = new Sound("mob.enderdragon.growl", 1f, 1f);
+
+  private static final Component WARN_SYMBOL =
+      new PersonalizedText(" \u26a0 ").color(ChatColor.YELLOW);
+  private static final Component BROADCAST_DIV =
+      new PersonalizedText(" \u00BB ").color(ChatColor.GOLD);
+  private static final Component CONSOLE_NAME =
+      new PersonalizedTranslatable("console")
+          .getPersonalizedText()
+          .color(ChatColor.DARK_AQUA)
+          .italic(true);
+
+  private final ChatDispatcher chat;
+
+  public ModerationCommands(ChatDispatcher chat) {
+    this.chat = chat;
+  }
+
+  @Command(
+      aliases = {"staff", "mods", "admins"},
+      desc = "List the online staff members")
+  public void staff(CommandSender sender, Match match) {
+    // List of online staff based off of permission
+    List<Component> onlineStaff =
+        match.getPlayers().stream()
+            .filter(player -> player.getBukkit().hasPermission(Permissions.STAFF))
+            .map(player -> player.getStyledName(NameStyle.FANCY))
+            .collect(Collectors.toList());
+
+    // FORMAT: Online Staff ({count}): {names}
+    Component staffCount =
+        new PersonalizedText(Integer.toString(onlineStaff.size()))
+            .color(onlineStaff.isEmpty() ? ChatColor.RED : ChatColor.AQUA);
+
+    Component content =
+        onlineStaff.isEmpty()
+            ? new PersonalizedTranslatable("moderation.staff.empty")
+                .getPersonalizedText()
+                .color(ChatColor.RED)
+            : new Component(
+                Components.join(new PersonalizedText(", ").color(ChatColor.GRAY), onlineStaff));
+
+    Component staff =
+        new PersonalizedTranslatable("moderation.staff.name", staffCount, content)
+            .getPersonalizedText()
+            .color(ChatColor.GRAY);
+
+    // Send message
+    sender.sendMessage(staff);
+  }
+
+  @Command(
+      aliases = {"mute", "m"},
+      usage = "<player> <reason> -s (silent) -w (warn)",
+      desc = "Mute a player",
+      perms = Permissions.MUTE)
+  public void mute(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent,
+      @Switch('w') boolean warn) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    if (chat.isMuted(targetMatchPlayer)) {
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.mute.existing", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .getPersonalizedText()
+              .color(ChatColor.RED));
+      return;
+    }
+
+    // if -w flag, also warn the player but don't broadcast warning
+    if (warn) {
+      warn(sender, target, match, reason, true);
+    }
+
+    if (punish(PunishmentType.MUTE, targetMatchPlayer, sender, reason, silent)) {
+      chat.addMuted(targetMatchPlayer);
+    }
+  }
+
+  @Command(
+      aliases = {"unmute", "um"},
+      usage = "<player>",
+      desc = "Unmute a player",
+      perms = Permissions.MUTE)
+  public void unMute(CommandSender sender, Player target, Match match) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+    if (chat.isMuted(targetMatchPlayer)) {
+      chat.removeMuted(targetMatchPlayer);
+
+      targetMatchPlayer.sendMessage(
+          new PersonalizedTranslatable("moderation.unmute.target")
+              .getPersonalizedText()
+              .color(ChatColor.GREEN));
+
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.unmute.sender", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .color(ChatColor.GRAY));
+    } else {
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.unmute.none", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .getPersonalizedText()
+              .color(ChatColor.RED));
+    }
+  }
+
+  @Command(
+      aliases = {"warn", "w"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Warn a player for bad behavior",
+      perms = Permissions.WARN)
+  public void warn(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    if (punish(PunishmentType.WARN, targetMatchPlayer, sender, reason, silent)) {
+      sendWarning(targetMatchPlayer, reason);
+    }
+  }
+
+  @Command(
+      aliases = {"kick", "k"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Kick a player from the server",
+      perms = Permissions.KICK)
+  public void kick(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+    if (punish(PunishmentType.KICK, targetMatchPlayer, sender, reason, silent)) {
+      target.kickPlayer(
+          formatPunishmentScreen(
+              PunishmentType.KICK, formatPunisherName(sender, match), reason, null));
+    }
+  }
+
+  @Command(
+      aliases = {"ban", "permban", "pb"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Ban a player from the server forever",
+      perms = Permissions.BAN)
+  public void ban(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+    Component senderName = formatPunisherName(sender, match);
+    if (punish(PunishmentType.BAN, targetMatchPlayer, sender, reason, silent)) {
+      banPlayer(target, reason, senderName, null);
+      target.kickPlayer(formatPunishmentScreen(PunishmentType.BAN, senderName, reason, null));
+    }
+  }
+
+  @Command(
+      aliases = {"tempban", "tban", "tb"},
+      usage = "<player> <time> <reason> -s (silent)",
+      desc = "Ban a player from the server for a period of time",
+      perms = Permissions.BAN)
+  public void tempBan(
+      CommandSender sender,
+      Player target,
+      Match match,
+      Duration banLength,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+    if (punish(PunishmentType.BAN, targetMatchPlayer, sender, reason, banLength, silent)) {
+      banPlayer(target, reason, formatPunisherName(sender, match), Instant.now().plus(banLength));
+      target.kickPlayer(
+          formatPunishmentScreen(
+              PunishmentType.BAN, formatPunisherName(sender, match), reason, banLength));
+    }
+  }
+
+  @Command(
+      aliases = {"ipban", "banip", "ipb"},
+      usage = "<player|ip address> <reason>",
+      desc = "IP Ban a player from the server",
+      perms = Permissions.BAN)
+  public void ipBan(
+      CommandSender sender,
+      MatchManager manager,
+      String target,
+      @Text String reason,
+      @Switch('s') boolean silent)
+      throws CommandException {
+    Player targetPlayer = Bukkit.getPlayerExact(target);
+
+    String address = target; // Default address to what was input
+
+    if (targetPlayer != null) {
+      // If target is a player, fetch their IP and use that
+      address = targetPlayer.getAddress().getAddress().getHostAddress();
+    }
+
+    // Validate if the IP is a valid IP
+    if (InetAddresses.isInetAddress(address)) {
+      // Special method for IP Ban
+      Bukkit.getBanList(BanList.Type.IP)
+          .addBan(
+              address,
+              reason,
+              null,
+              ComponentRenderers.toLegacyText(
+                  formatPunisherName(sender, manager.getMatch(sender)), sender));
+
+      // Check all online players to find those with same IP.
+      for (Player player : Bukkit.getOnlinePlayers()) {
+        MatchPlayer matchPlayer = manager.getPlayer(player);
+        if (player.getAddress().getAddress().getHostAddress().equals(address)) {
+          // Kick players with same IP
+          if (punish(PunishmentType.BAN, matchPlayer, sender, reason, silent)) {
+            player.kickPlayer(
+                formatPunishmentScreen(
+                    PunishmentType.BAN,
+                    formatPunisherName(sender, manager.getMatch(sender)),
+                    reason,
+                    null));
+          }
+        }
+      }
+    } else {
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.commands.invalidIP",
+                  new PersonalizedText(address).color(ChatColor.RED).italic(true))
+              .color(ChatColor.GRAY));
+    }
+  }
+
+  private boolean punish(
+      PunishmentType type,
+      MatchPlayer target,
+      CommandSender issuer,
+      String reason,
+      boolean silent) {
+    return punish(type, target, issuer, reason, Duration.ZERO, silent);
+  }
+
+  private boolean punish(
+      PunishmentType type,
+      MatchPlayer target,
+      CommandSender issuer,
+      String reason,
+      Duration duration,
+      boolean silent) {
+    PlayerPunishmentEvent event =
+        new PlayerPunishmentEvent(issuer, target, type, reason, duration, silent);
+    target.getMatch().callEvent(event);
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        issuer.sendMessage(event.getCancelMessage());
+      }
+    } else if (!silent) {
+      broadcastPunishment(event);
+    }
+    return !event.isCancelled();
+  }
+
+  public static enum PunishmentType {
+    MUTE(false),
+    WARN(false),
+    KICK(true),
+    BAN(true);
+
+    private String PREFIX_TRANSLATE_KEY = "moderation.type.";
+    private String SCREEN_TRANSLATE_KEY = "moderation.screen.";
+
+    private final boolean screen;
+
+    PunishmentType(boolean screen) {
+      this.screen = screen;
+    }
+
+    public Component getPunishmentPrefix() {
+      return new PersonalizedTranslatable(PREFIX_TRANSLATE_KEY + name().toLowerCase())
+          .getPersonalizedText()
+          .color(ChatColor.RED);
+    }
+
+    public Component getScreenComponent(Component reason) {
+      if (!screen) return Components.blank();
+      return new PersonalizedTranslatable(SCREEN_TRANSLATE_KEY + name().toLowerCase(), reason)
+          .getPersonalizedText()
+          .color(ChatColor.GOLD);
+    }
+  }
+
+  /*
+   * Format Punisher Name
+   */
+  public static Component formatPunisherName(CommandSender sender, Match match) {
+    if (sender != null && sender instanceof Player) {
+      MatchPlayer matchPlayer = match.getPlayer((Player) sender);
+      if (matchPlayer != null) return matchPlayer.getStyledName(NameStyle.FANCY);
+    }
+    return CONSOLE_NAME;
+  }
+
+  /*
+   * Format Reason
+   */
+  public static Component formatPunishmentReason(String reason) {
+    return new PersonalizedText(reason).color(ChatColor.RED);
+  }
+
+  /*
+   * Formatting of Kick Screens (KICK/BAN/TEMPBAN)
+   */
+  public static String formatPunishmentScreen(
+      PunishmentType type, Component punisher, String reason, @Nullable Duration expires) {
+    List<Component> lines = Lists.newArrayList();
+
+    Component header =
+        new PersonalizedText(
+            ComponentUtils.horizontalLineHeading(
+                Config.Moderation.getServerName(), ChatColor.DARK_GRAY));
+
+    Component footer =
+        new PersonalizedText(
+            ComponentUtils.horizontalLine(ChatColor.DARK_GRAY, ComponentUtils.MAX_CHAT_WIDTH));
+
+    Component rules = new PersonalizedText(Config.Moderation.getRulesLink()).color(ChatColor.AQUA);
+
+    lines.add(header); // Header Line (server name) - START
+    lines.add(Components.blank());
+    lines.add(type.getScreenComponent(formatPunishmentReason(reason))); // The reason
+    lines.add(Components.blank());
+
+    // If punishment expires, inform user when
+    if (expires != null) {
+      Component timeLeft =
+          PeriodFormats.briefNaturalApproximate(
+              org.joda.time.Duration.standardSeconds(expires.getSeconds()));
+      lines.add(
+          new PersonalizedTranslatable("moderation.screen.expires", timeLeft)
+              .getPersonalizedText()
+              .color(ChatColor.GRAY));
+      lines.add(Components.blank());
+    }
+
+    // Staff sign-off
+    lines.add(
+        new PersonalizedTranslatable("moderation.screen.signoff", punisher)
+            .getPersonalizedText()
+            .color(ChatColor.GRAY)); // The sign-off of who performed the punishment
+
+    // Link to rules for review by player
+    if (Config.Moderation.isRuleLinkVisible()) {
+      lines.add(Components.blank());
+      lines.add(
+          new PersonalizedTranslatable("moderation.screen.rulesLink", rules)
+              .getPersonalizedText()
+              .color(ChatColor.GRAY)); // A link to the rules
+    }
+
+    // Configurable last line (for appeal message or etc)
+    if (Config.Moderation.isAppealVisible() && type.equals(PunishmentType.BAN)) {
+      lines.add(Components.blank());
+      lines.add(new PersonalizedText(Config.Moderation.getAppealMessage()));
+    }
+
+    lines.add(Components.blank());
+    lines.add(footer); // Footer line - END
+
+    return Components.join(new PersonalizedText("\n" + ChatColor.RESET), lines).toLegacyText();
+  }
+
+  /*
+   * Sends a formatted title and plays a sound warning a user of their actions
+   */
+  private void sendWarning(MatchPlayer target, String reason) {
+    Component titleWord =
+        new PersonalizedTranslatable("moderation.warning")
+            .getPersonalizedText()
+            .color(ChatColor.DARK_RED);
+    Component title = new PersonalizedText(WARN_SYMBOL, titleWord, WARN_SYMBOL);
+    Component subtitle = formatPunishmentReason(reason).color(ChatColor.GOLD);
+
+    target.showTitle(title, subtitle, 5, 200, 10);
+    target.playSound(WARN_SOUND);
+  }
+
+  private void broadcastPunishment(PlayerPunishmentEvent event) {
+    broadcastPunishment(
+        event.getType(),
+        event.getPlayer().getMatch(),
+        event.getSender(),
+        event.getPlayer(),
+        event.getReason(),
+        event.isSilent());
+  }
+
+  /*
+   * Broadcasts a punishment
+   */
+  private void broadcastPunishment(
+      PunishmentType type,
+      Match match,
+      CommandSender sender,
+      MatchPlayer target,
+      String reason,
+      boolean silent) {
+    Component prefix =
+        new PersonalizedText(
+            new PersonalizedText("[").color(ChatColor.GOLD),
+            type.getPunishmentPrefix(),
+            new PersonalizedText("]").color(ChatColor.GOLD));
+    Component targetName = target.getStyledName(NameStyle.FANCY);
+    Component reasonMsg = ModerationCommands.formatPunishmentReason(reason);
+    Component formattedMsg =
+        new PersonalizedText(
+            prefix,
+            Components.space(),
+            ModerationCommands.formatPunisherName(sender, match),
+            BROADCAST_DIV,
+            targetName,
+            BROADCAST_DIV,
+            reasonMsg);
+
+    if (!silent) {
+      match.sendMessage(formattedMsg);
+    } else {
+      // if silent flag present, only notify sender
+      sender.sendMessage(formattedMsg);
+    }
+  }
+
+  /*
+   * Bukkit method of banning players
+   * NOTE: Will use this if not handled by other plugins
+   */
+  private void banPlayer(
+      Player target, String reason, Component source, @Nullable Instant expires) {
+    Bukkit.getBanList(BanList.Type.NAME)
+        .addBan(
+            target.getName(),
+            reason,
+            expires != null ? Date.from(expires) : null,
+            ComponentRenderers.toLegacyText(source, target));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -1,0 +1,272 @@
+package tc.oc.pgm.community.commands;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.CommandException;
+import app.ashcon.intake.bukkit.parametric.Type;
+import app.ashcon.intake.bukkit.parametric.annotation.Fallback;
+import app.ashcon.intake.parametric.annotation.Default;
+import app.ashcon.intake.parametric.annotation.Switch;
+import app.ashcon.intake.parametric.annotation.Text;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.HoverEvent.Action;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.chat.Audience;
+import tc.oc.pgm.api.chat.Sound;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.events.PlayerReportEvent;
+import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.util.bukkit.component.Component;
+import tc.oc.util.bukkit.component.ComponentRenderers;
+import tc.oc.util.bukkit.component.ComponentUtils;
+import tc.oc.util.bukkit.component.PeriodFormats;
+import tc.oc.util.bukkit.component.types.PersonalizedText;
+import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
+import tc.oc.util.bukkit.named.NameStyle;
+
+public class ReportCommands {
+
+  private static final Sound REPORT_NOTIFY_SOUND = new Sound("random.pop", 1f, 1.2f);
+
+  private static final int REPORT_COOLDOWN_SECONDS = 15;
+  private static final int REPORT_EXPIRE_HOURS = 1;
+
+  private final Cache<UUID, Instant> LAST_REPORT_SENT =
+      CacheBuilder.newBuilder().expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS).build();
+
+  private final Cache<UUID, Report> RECENT_REPORTS =
+      CacheBuilder.newBuilder().expireAfterWrite(REPORT_EXPIRE_HOURS, TimeUnit.HOURS).build();
+
+  @Command(
+      aliases = {"report"},
+      usage = "<player> <reason>",
+      desc = "Report a player who is breaking the rules")
+  public void report(
+      CommandSender commandSender,
+      MatchPlayer matchPlayer,
+      Match match,
+      Player player,
+      @Text String reason)
+      throws CommandException {
+    if (!commandSender.hasPermission(Permissions.STAFF) && commandSender instanceof Player) {
+      // Check for cooldown
+      Instant lastReport = LAST_REPORT_SENT.getIfPresent(matchPlayer.getId());
+      if (lastReport != null) {
+        Duration timeSinceReport = Duration.between(lastReport, Instant.now());
+        long secondsRemaining = REPORT_COOLDOWN_SECONDS - timeSinceReport.getSeconds();
+        if (secondsRemaining > 0) {
+          Component secondsComponent = new PersonalizedText(Long.toString(secondsRemaining));
+          Component secondsLeftComponent =
+              new PersonalizedTranslatable(
+                      secondsRemaining != 1
+                          ? "countdown.pluralCompound"
+                          : "countdown.singularCompound",
+                      secondsComponent)
+                  .getPersonalizedText()
+                  .color(ChatColor.AQUA);
+          commandSender.sendMessage(
+              new PersonalizedTranslatable("command.cooldown", secondsLeftComponent)
+                  .getPersonalizedText()
+                  .color(ChatColor.RED));
+          return;
+        }
+      } else {
+        // Player has no cooldown, so add one
+        LAST_REPORT_SENT.put(matchPlayer.getId(), Instant.now());
+      }
+    }
+
+    MatchPlayer accused = match.getPlayer(player);
+    PlayerReportEvent event = new PlayerReportEvent(commandSender, accused, reason);
+    match.callEvent(event);
+
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        commandSender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    }
+
+    commandSender.sendMessage(
+        new PersonalizedText(
+            new PersonalizedText(new PersonalizedTranslatable("misc.thankYou"), ChatColor.GREEN),
+            new PersonalizedText(" "),
+            new PersonalizedText(
+                new PersonalizedTranslatable("command.report.acknowledge"), ChatColor.GOLD)));
+
+    final Component component =
+        new PersonalizedTranslatable(
+            "command.report.notify",
+            matchPlayer == null
+                ? new PersonalizedText("Console", ChatColor.AQUA, ChatColor.ITALIC)
+                : matchPlayer.getStyledName(NameStyle.FANCY),
+            accused.getStyledName(NameStyle.FANCY),
+            new PersonalizedText(reason.trim(), ChatColor.WHITE));
+
+    RECENT_REPORTS.put(
+        UUID.randomUUID(),
+        new Report(
+            player.getName(),
+            reason,
+            accused.getStyledName(NameStyle.CONCISE),
+            matchPlayer.getStyledName(NameStyle.CONCISE)));
+
+    final Component prefixedComponent =
+        new PersonalizedText(
+            new PersonalizedText("["),
+            new PersonalizedText("A", ChatColor.GOLD),
+            new PersonalizedText("] "),
+            new PersonalizedText(component, ChatColor.YELLOW));
+
+    match.getPlayers().stream()
+        .filter(viewer -> viewer.getBukkit().hasPermission(Permissions.ADMINCHAT))
+        .forEach(
+            viewer -> {
+              // Play sound for viewers of reports
+              if (viewer.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ON)) {
+                viewer.playSound(REPORT_NOTIFY_SOUND);
+              }
+              viewer.sendMessage(prefixedComponent);
+            });
+    Audience.get(Bukkit.getConsoleSender()).sendMessage(component);
+  }
+
+  @Command(
+      aliases = {"reports", "reps", "reporthistory"},
+      desc = "Display a list of recent reports",
+      usage = "(page) -t [target player]",
+      flags = "t",
+      perms = Permissions.STAFF)
+  public void reportHistory(
+      Audience audience,
+      CommandSender sender,
+      @Default("1") int page,
+      @Fallback(Type.NULL) @Switch('t') String target)
+      throws CommandException {
+    if (RECENT_REPORTS.asMap().isEmpty()) {
+      sender.sendMessage(
+          new PersonalizedTranslatable("moderation.reports.none")
+              .getPersonalizedText()
+              .color(ChatColor.RED));
+      return;
+    }
+
+    List<Report> reportList = RECENT_REPORTS.asMap().values().stream().collect(Collectors.toList());
+    if (target != null) {
+      reportList =
+          reportList.stream()
+              .filter(r -> r.getId().equalsIgnoreCase(target))
+              .collect(Collectors.toList());
+    }
+
+    Collections.sort(reportList); // Sort list
+    Collections.reverse(reportList); // Reverse so most recent show up first
+
+    Component headerResultCount =
+        new PersonalizedText(Long.toString(reportList.size())).color(ChatColor.RED);
+
+    int perPage = 6;
+    int pages = (reportList.size() + perPage - 1) / perPage;
+
+    Component pageNum =
+        new PersonalizedTranslatable(
+                "command.paginatedResult.page",
+                new PersonalizedText(Integer.toString(page)).color(ChatColor.RED),
+                new PersonalizedText(Integer.toString(pages)).color(ChatColor.RED))
+            .add(ChatColor.AQUA);
+
+    Component header =
+        new PersonalizedText(
+            new PersonalizedTranslatable("moderation.reports.header", headerResultCount, pageNum)
+                .getPersonalizedText()
+                .color(ChatColor.GRAY),
+            new PersonalizedText(" ("),
+            headerResultCount,
+            new PersonalizedText(") » "),
+            pageNum);
+
+    Component formattedHeader =
+        new PersonalizedText(
+            ComponentUtils.horizontalLineHeading(
+                ComponentRenderers.toLegacyText(header, sender), ChatColor.WHITE));
+
+    new PrettyPaginatedComponentResults<Report>(formattedHeader, perPage) {
+      @Override
+      public Component format(Report data, int index) {
+        Component timeAgo =
+            PeriodFormats.relativePastApproximate(
+                    org.joda.time.Instant.ofEpochMilli(data.getTimeSent().toEpochMilli()))
+                .color(ChatColor.DARK_AQUA);
+        Component hover =
+            new PersonalizedTranslatable("moderation.reports.hover", data.getSenderName())
+                .getPersonalizedText()
+                .color(ChatColor.GRAY);
+
+        Component formatted =
+            new PersonalizedText(
+                timeAgo,
+                new PersonalizedText(": ").color(ChatColor.GRAY),
+                data.getTargetName(),
+                new PersonalizedText(" « ").color(ChatColor.YELLOW),
+                new PersonalizedText(data.getReason()).italic(true).color(ChatColor.WHITE));
+
+        return formatted.hoverEvent(Action.SHOW_TEXT, hover.render(sender));
+      }
+    }.display(audience, reportList, page);
+  }
+
+  public static class Report implements Comparable<Report> {
+    private final String id;
+    private final String reason;
+    private final Component targetName;
+    private final Component sender;
+    private final Instant timeSent;
+
+    public Report(String id, String reason, Component targetName, Component sender) {
+      this.id = id;
+      this.reason = reason;
+      this.targetName = targetName;
+      this.sender = sender;
+      this.timeSent = Instant.now();
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+
+    public Component getTargetName() {
+      return targetName;
+    }
+
+    public Component getSenderName() {
+      return sender;
+    }
+
+    public Instant getTimeSent() {
+      return timeSent;
+    }
+
+    @Override
+    public int compareTo(Report o) {
+      return getTimeSent().compareTo(o.getTimeSent());
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/community/events/PlayerPunishmentEvent.java
+++ b/core/src/main/java/tc/oc/pgm/community/events/PlayerPunishmentEvent.java
@@ -1,0 +1,71 @@
+package tc.oc.pgm.community.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.event.ExtendedCancellable;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.community.commands.ModerationCommands.PunishmentType;
+
+/** Called when a punishment command is run * */
+public class PlayerPunishmentEvent extends ExtendedCancellable {
+
+  private final CommandSender sender;
+  private final MatchPlayer player;
+  private final PunishmentType punishment;
+  private final String reason;
+  private final Duration duration;
+  private final boolean silent;
+
+  public PlayerPunishmentEvent(
+      CommandSender sender,
+      MatchPlayer player,
+      PunishmentType punishment,
+      String reason,
+      Duration duration,
+      boolean silent) {
+    this.sender = checkNotNull(sender);
+    this.player = checkNotNull(player);
+    this.punishment = checkNotNull(punishment);
+    this.reason = checkNotNull(reason);
+    this.duration = checkNotNull(duration);
+    this.silent = checkNotNull(silent);
+  }
+
+  public CommandSender getSender() {
+    return sender;
+  }
+
+  public PunishmentType getType() {
+    return punishment;
+  }
+
+  public MatchPlayer getPlayer() {
+    return player;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public boolean isSilent() {
+    return silent;
+  }
+
+  public Duration getDuration() {
+    return duration;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
+++ b/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
@@ -1,0 +1,109 @@
+package tc.oc.pgm.util;
+
+import app.ashcon.intake.CommandException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import tc.oc.pgm.api.chat.Audience;
+import tc.oc.util.bukkit.component.Component;
+
+public abstract class PrettyPaginatedComponentResults<T> {
+
+  private Component header;
+  private int resultsPerPage;
+
+  /**
+   * Constructor
+   *
+   * @param header list header
+   * @param resultsPerPage results per page
+   */
+  public PrettyPaginatedComponentResults(Component header, int resultsPerPage) {
+    this.header = header;
+    this.resultsPerPage = resultsPerPage;
+  }
+
+  /**
+   * Constructor
+   *
+   * @param header list header
+   */
+  public PrettyPaginatedComponentResults(Component header) {
+    this(header, 6);
+  }
+
+  /**
+   * Formats the lists' header
+   *
+   * @param header to be formatted
+   * @param currentPage being displayed
+   * @param pages total pages
+   * @return Formatted header
+   */
+  public Component formatHeader(Component header, int currentPage, int pages) {
+    return header;
+  }
+
+  /**
+   * Formats a the type data into a string
+   *
+   * @param data to format
+   * @param index if the data
+   * @return Formatted item
+   */
+  public abstract Component format(T data, int index);
+
+  /**
+   * Format sent to the player if no data is provided
+   *
+   * @return Formatted message
+   * @throws CommandException default implementation exception
+   */
+  public Component formatEmpty() throws CommandException {
+    throw new CommandException("No results match!");
+  }
+
+  /**
+   * Displays a list of items based on the page to an audience
+   *
+   * @param audience to display data to
+   * @param data to display
+   * @param page where the data is located
+   * @throws CommandException no match exceptions
+   */
+  public void display(Audience audience, Collection<? extends T> data, int page)
+      throws CommandException {
+    display(audience, new ArrayList<>(data), page);
+  }
+
+  /**
+   * Displays a list of items based on the page to an audience
+   *
+   * @param audience to display data to
+   * @param data to display
+   * @param page where the data is located
+   * @throws CommandException no match exceptions
+   */
+  public void display(Audience audience, List<? extends T> data, int page) throws CommandException {
+    if (data.size() == 0) {
+      audience.sendMessage(formatEmpty());
+      return;
+    }
+
+    int maxPages = data.size() / this.resultsPerPage + 1;
+
+    if (data.size() % this.resultsPerPage == 0) {
+      maxPages--;
+    }
+
+    if (page <= 0 || page > maxPages)
+      throw new CommandException("Unknown page selected! " + maxPages + " total pages.");
+
+    audience.sendMessage(header);
+    for (int i = resultsPerPage * (page - 1);
+        i < this.resultsPerPage * page && i < data.size();
+        i++) {
+      audience.sendMessage(format(data.get(i), i));
+    }
+  }
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -109,3 +109,14 @@ sidebar:
   bottom: ""
   # If the sidebar message should overwrite lines in the sidebar when it is full
   overwrite: false
+  
+# Note: All moderation fields may be formatted with '&' color codes
+moderation:
+  # Name of server to display on kick screen header
+  server-name: ''
+
+  # Link to a rules website to display on kick screens
+  rules-link: ''
+    
+  # Last message line shown on ban/temp-ban kick screen
+  appeal-msg: ''

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -898,3 +898,49 @@ observer.tools.visibility.hidden = Hidden
 # {1} = List of staff players
 moderation.staff.name = Online Staff ({0}): {1}
 moderation.staff.empty = No staff online :(
+
+# {0} = Reason for punishment
+moderation.screen.kick = You were kicked for {0}
+moderation.screen.ban = You were banned for {0}
+
+# {0} = Formatted date of expiry
+moderation.screen.banExpire = Expires on {0}
+
+moderation.screen.rulesLink = Please review our rules at {0}
+
+# {0} = Name of staff member 
+moderation.screen.signoff = Issued by {0}
+
+# {0} = Time until the ban expires
+moderation.screen.expires = Expires in {0}
+
+moderation.warning = WARNING
+
+moderation.mute.message = You have been muted and are unable to send chat messages.
+
+# {0} = Name of muted player
+moderation.mute.existing = {0} is already muted!
+
+moderation.type.kick = Kick
+moderation.type.mute = Mute
+moderation.type.warn = Warn
+moderation.type.ban = Ban
+
+# {0} = Name of unmuted target
+moderation.unmute.sender = You have unmuted {0}
+moderation.unmute.target = You have been unmuted and may now send messages
+
+# {0} = Name of target
+moderation.unmute.none = {0} is not muted.
+
+moderation.reports.none = There have been no recent reports!
+
+moderation.reports.header = Recent Reports
+
+# {0} = Name of reporter
+# {1} = Time ago
+moderation.reports.hover = Reported by {0}
+
+# {0} = IP address
+moderation.commands.banIP = The IP address ({0}) has been banned.
+moderation.commands.invalidIP = {0} is not a valid IP address.

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/named/NameStyle.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/named/NameStyle.java
@@ -12,7 +12,8 @@ public enum NameStyle {
   TAB(
       true, true, true, true, true, false, true,
       true), // Color, flair, friend status, nick status, death status
-  VERBOSE(true, true, true, true, true, true, false, true); // Fancy plus nickname
+  VERBOSE(true, true, true, true, true, true, false, true), // Fancy plus nickname
+  CONCISE(true, true, true, true, true, true, false, false); // Verbose, but removes teleport
 
   public final boolean isColor;
   public final boolean showPrefix;


### PR DESCRIPTION
# Add moderation commands 🎉 🎉 

There has been a lapse of time since my previous work on the moderation commands, but I’m making this draft PR in preparation for the community module that is coming soon. With this large refactor #332 by @Electroid, I’m unsure whether this should be merged before or after it is complete. All changes in this PR have been tested and should work properly. Please see #300 for examples of the screenshots, though some minor formatting adjustments may have been made between then and now. 

## Outline of major changes:
- Added  moderation commands (`/warn`, `/mute`, `/unmute`, `/kick`, `/ban`, `/tempban`)
- Split report related commands from moderation into own class 
- Added caching of all reports sent, with a `/reports` command for staff to view them in a list

### Note about switching from external ban plugins to PGM bans:
The ban commands here utilize the bukkit format of banning/temp-banning players. So if a server was utilizing say command book, unless an a transfer is performed no previous bans will be active.

To solve this for those who utilize command book, I’ve made a [fork](https://github.com/applenick/CommandBook) that adds a `/bans convert` command to transfer all bans to the bukkit style, thus allowing PGM bans to take them into account.  

## Final Note:
There is not much else I would add at this point to the moderation commands. I do plan on looking into additional features such as `/vanish` in the future, but would prefer the community module becomes more established before that happens. 

Also I would ideally like to have PGM listen for players who are banned/temp-banned to bypass the bukkit formatting screens. Though I have not included this feature yet, let me know if that would be acceptable to add and I can look into it.

If anyone has suggestions as to the current changes, I’m open to making modifications. 

@Electroid let me know if you feel it would be better to merge these changes before or after the modules refractor takes place, and I’d be down to help out any way I can.

Signed-off-by: applenick <applenick@users.noreply.github.com>