### PR TITLE
Fix observer item drops in match start phase

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -308,6 +308,8 @@ public class PGMListener implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void dropItemsOnQuit(PlayerParticipationStopEvent event) {
+    if (!event.getMatch().isRunning()) return;
+
     MatchPlayer quitter = event.getPlayer();
     for (ItemStack item : quitter.getInventory().getContents()) {
       if (item == null || item.getType() == Material.AIR) continue;


### PR DESCRIPTION
Prevents "match players" dropping items on disconnect outside of match running state.

This fixes "players" who had joined during the start countdown dropping all of the items once leaving.

Signed-off-by: Pugzy <pugzy@mail.com>