### PR TITLE
Use alive player state in item drop check

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -308,9 +308,9 @@ public class PGMListener implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void dropItemsOnQuit(PlayerParticipationStopEvent event) {
-    if (!event.getMatch().isRunning()) return;
-
     MatchPlayer quitter = event.getPlayer();
+    if (!quitter.isAlive()) return;
+
     for (ItemStack item : quitter.getInventory().getContents()) {
       if (item == null || item.getType() == Material.AIR) continue;
       quitter.getWorld().dropItemNaturally(quitter.getBukkit().getLocation(), item);


### PR DESCRIPTION
Real fix this time. No more games.

I forgot that the match can be running and players can enter a state where dropping items would not be ideal i.e dead, waiting to spawn due to filters etc. Only players in the alive state should drop items.

Signed-off-by: Pugzy <pugzy@mail.com>