### PR TITLE
Fix NPE from offline ban command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/Config.java
+++ b/core/src/main/java/tc/oc/pgm/Config.java
@@ -23,6 +23,7 @@ import tc.oc.pgm.api.map.factory.MapSourceFactory;
 import tc.oc.pgm.events.ConfigLoadEvent;
 import tc.oc.pgm.map.source.DefaultMapSourceFactory;
 import tc.oc.pgm.map.source.SystemMapSourceFactory;
+import tc.oc.util.bukkit.BukkitUtils;
 
 public class Config {
 
@@ -461,17 +462,15 @@ public class Config {
     }
 
     public static String getRulesLink() {
-      return getConfiguration().getString("moderation.rules-link", "");
+      return BukkitUtils.colorize(getConfiguration().getString("moderation.rules-link", ""));
     }
 
     public static String getServerName() {
-      return ChatColor.translateAlternateColorCodes(
-          '&', getConfiguration().getString("moderation.server-name", ""));
+      return BukkitUtils.colorize(getConfiguration().getString("moderation.server-name", ""));
     }
 
     public static String getAppealMessage() {
-      return ChatColor.translateAlternateColorCodes(
-          '&', getConfiguration().getString("moderation.appeal-msg", ""));
+      return BukkitUtils.colorize(getConfiguration().getString("moderation.appeal-msg", ""));
     }
 
     public static boolean isAppealVisible() {

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -603,7 +603,8 @@ public class ModerationCommands {
       Duration duration,
       boolean silent) {
     PlayerPunishmentEvent event =
-        new PlayerPunishmentEvent(issuer, target, type, reason, duration == null ? Duration.ZERO : duration, silent);
+        new PlayerPunishmentEvent(
+            issuer, target, type, reason, duration == null ? Duration.ZERO : duration, silent);
     target.getMatch().callEvent(event);
     if (event.isCancelled()) {
       if (event.getCancelMessage() != null) {
@@ -686,8 +687,6 @@ public class ModerationCommands {
         new PersonalizedText(
             ComponentUtils.horizontalLine(ChatColor.DARK_GRAY, ComponentUtils.MAX_CHAT_WIDTH));
 
-    Component rules = new PersonalizedText(Config.Moderation.getRulesLink()).color(ChatColor.AQUA);
-
     lines.add(header); // Header Line (server name) - START
     lines.add(Components.blank());
     lines.add(type.getScreenComponent(formatPunishmentReason(reason))); // The reason
@@ -713,6 +712,8 @@ public class ModerationCommands {
 
     // Link to rules for review by player
     if (Config.Moderation.isRuleLinkVisible()) {
+      Component rules = new PersonalizedText(Config.Moderation.getRulesLink());
+
       lines.add(Components.blank());
       lines.add(
           new PersonalizedTranslatable("moderation.screen.rulesLink", rules)
@@ -771,7 +772,7 @@ public class ModerationCommands {
       Duration length) {
 
     Component prefix = type.getPunishmentPrefix();
-    if (!length.isZero()) {
+    if (length != null && !length.isZero()) {
       String time =
           ComponentRenderers.toLegacyText(
               PeriodFormats.briefNaturalApproximate(


### PR DESCRIPTION
Following #341 being merged, it seems a few NPE errors slipped through. Thank you @Electroid for patching the problem earlier, I went through and found the remaining error affecting the `/offlineban` command and this should serve as a final patch for that. 

Also @Brottweiler wanted to have the formatting fixed for the rules link on kick screens, so I went ahead and included that here too. 

Signed-off-by: applenick <applenick@users.noreply.github.com>