### PR TITLE
Chat and Sound improvements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -30,7 +30,7 @@ public enum SettingKey {
       player.resetVisibility();
     }
   }, // Changes if observers are visible
-  SOUNDS("sounds", SOUNDS_ON, SOUNDS_OFF), // Changes if sounds are played
+  SOUNDS("sounds", SOUNDS_ALL, SOUNDS_DM, SOUNDS_NONE), // Changes when sounds are played
   VOTE("vote", VOTE_ON, VOTE_OFF), // Changes if the vote book is shown on cycle
   ;
 

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -34,8 +34,9 @@ public enum SettingValue {
   OBSERVERS_ON("observers", "on"), // Show observers
   OBSERVERS_OFF("observers", "off"), // Hide observers
 
-  SOUNDS_ON("sounds", "on"), // Always play sounds
-  SOUNDS_OFF("sounds", "off"), // Never play sounds
+  SOUNDS_ALL("sounds", "all"), // Play all sounds
+  SOUNDS_DM("sounds", "messages"), // Only play DM sounds
+  SOUNDS_NONE("sounds", "none"), // Never play sounds
 
   VOTE_ON("vote", "on"), // Show the vote book on cycle
   VOTE_OFF("vote", "off"), // Don't show the vote book on cycle

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -29,6 +29,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.events.PlayerReportEvent;
+import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
 import tc.oc.util.bukkit.component.Component;
 import tc.oc.util.bukkit.component.ComponentRenderers;
@@ -127,9 +128,7 @@ public class ReportCommands {
 
     final Component prefixedComponent =
         new PersonalizedText(
-            new PersonalizedText("["),
-            new PersonalizedText("A", ChatColor.GOLD),
-            new PersonalizedText("] "),
+            new PersonalizedText(ChatDispatcher.ADMIN_CHAT_PREFIX),
             new PersonalizedText(component, ChatColor.YELLOW));
 
     match.getPlayers().stream()
@@ -137,7 +136,10 @@ public class ReportCommands {
         .forEach(
             viewer -> {
               // Play sound for viewers of reports
-              if (viewer.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ON)) {
+              if (viewer
+                  .getSettings()
+                  .getValue(SettingKey.SOUNDS)
+                  .equals(SettingValue.SOUNDS_ALL)) {
                 viewer.playSound(REPORT_NOTIFY_SOUND);
               }
               viewer.sendMessage(prefixedComponent);

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -34,6 +34,7 @@ import tc.oc.util.StringUtils;
 import tc.oc.util.bukkit.BukkitUtils;
 import tc.oc.util.bukkit.OnlinePlayerMapAdapter;
 import tc.oc.util.bukkit.component.Component;
+import tc.oc.util.bukkit.component.ComponentRenderers;
 import tc.oc.util.bukkit.component.Components;
 import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
@@ -53,8 +54,7 @@ public class ChatDispatcher implements Listener {
   private static final String DM_SYMBOL = "@";
   private static final String ADMIN_CHAT_SYMBOL = "$";
 
-  public static final String ADMIN_CHAT_PREFIX = "[" + ChatColor.RED + "A" + ChatColor.WHITE + "]";
-  private static final String DM_CHAT_PREFIX = "[" + ChatColor.GOLD + "DM" + ChatColor.WHITE + "]";
+  public static final String ADMIN_CHAT_PREFIX = "[" + ChatColor.GOLD + "A" + ChatColor.WHITE + "]";
 
   public ChatDispatcher(MatchManager manager) {
     this.manager = manager;
@@ -189,7 +189,7 @@ public class ChatDispatcher implements Listener {
         match,
         sender,
         message,
-        DM_CHAT_PREFIX + " {0}: {1}",
+        ComponentRenderers.toLegacyText(formatPrivateMessage("command.message.from"), receiver),
         viewer -> viewer.getBukkit().equals(receiver),
         null);
 
@@ -197,7 +197,8 @@ public class ChatDispatcher implements Listener {
         match,
         manager.getPlayer(receiver), // Allow for cross-match messages
         message,
-        DM_CHAT_PREFIX + " -> {0}: {1}",
+        ComponentRenderers.toLegacyText(
+            formatPrivateMessage("command.message.to"), manager.getPlayer(receiver).getBukkit()),
         viewer -> viewer.getBukkit().equals(sender.getBukkit()),
         null);
   }
@@ -215,6 +216,12 @@ public class ChatDispatcher implements Listener {
     }
 
     sendDirect(match, sender, receiver.getBukkit(), message);
+  }
+
+  private static PersonalizedText formatPrivateMessage(String key) {
+    return new PersonalizedText(
+        new PersonalizedTranslatable(key).getPersonalizedText().color(ChatColor.GRAY).italic(true),
+        new PersonalizedText(" {0}: {1}"));
   }
 
   private static MatchPlayer getApproximatePlayer(Match match, String query, CommandSender sender) {

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -53,8 +53,7 @@ public class ChatDispatcher implements Listener {
   private static final String DM_SYMBOL = "@";
   private static final String ADMIN_CHAT_SYMBOL = "$";
 
-  public static final String ADMIN_CHAT_PREFIX =
-      "[" + ChatColor.DARK_RED + "A" + ChatColor.WHITE + "]";
+  public static final String ADMIN_CHAT_PREFIX = "[" + ChatColor.RED + "A" + ChatColor.WHITE + "]";
   private static final String DM_CHAT_PREFIX = "[" + ChatColor.GOLD + "DM" + ChatColor.WHITE + "]";
 
   public ChatDispatcher(MatchManager manager) {

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -237,7 +237,7 @@ public class ChatDispatcher implements Listener {
   }
 
   @Command(
-      aliases = {"say", "send", "sendteam"},
+      aliases = {"s", "say", "send", "sendteam"},
       desc = "Send a message to a specfic team chat",
       usage = "[team] [message]",
       perms = Permissions.STAFF)

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -236,45 +236,6 @@ public class ChatDispatcher implements Listener {
     sendDirect(match, sender, receiver.getBukkit(), message);
   }
 
-  @Command(
-      aliases = {"s", "say", "send", "sendteam"},
-      desc = "Send a message to a specfic team chat",
-      usage = "[team] [message]",
-      perms = Permissions.STAFF)
-  public void sendOtherTeamChat(
-      MatchPlayer player, Match match, String targetParty, @Text String message) {
-    Party party = getApproximateParty(match, targetParty);
-
-    if (party == null) {
-      player.sendWarning(
-          new PersonalizedTranslatable(
-              "commands.chat.send.noParty", new PersonalizedText(message).color(ChatColor.AQUA)));
-      return;
-    }
-
-    if (match.isFinished() || party instanceof Tribute) {
-      player.sendWarning(new PersonalizedTranslatable("commands.chat.send.finished"));
-      return;
-    }
-
-    if (!player.isObserving()) {
-      player.sendWarning(new PersonalizedTranslatable("commands.chat.send.notObs"));
-      return;
-    }
-
-    // Same format as team chat command
-    send(
-        match,
-        player,
-        message,
-        party.getChatPrefix().toLegacyText() + PREFIX_FORMAT,
-        viewer ->
-            party.equals(viewer.getParty())
-                || (viewer.isObserving()
-                    && viewer.getBukkit().hasPermission(Permissions.ADMINCHAT)),
-        SettingValue.CHAT_TEAM);
-  }
-
   @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
   public void onChat(AsyncPlayerChatEvent event) {
     event.setCancelled(true);
@@ -366,14 +327,6 @@ public class ChatDispatcher implements Listener {
                 new PersonalizedText(message.trim())));
     match.getPlayers().stream().filter(filter).forEach(player -> player.sendMessage(component));
     Audience.get(Bukkit.getConsoleSender()).sendMessage(component);
-  }
-
-  private Party getApproximateParty(Match match, String query) {
-    return StringUtils.bestFuzzyMatch(
-        query,
-        match.getParties().stream()
-            .collect(Collectors.toMap(party -> party.getName(), Function.identity())),
-        0.75);
   }
 
   private MatchPlayer getApproximatePlayer(Match match, String query, CommandSender sender) {

--- a/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
@@ -34,7 +34,7 @@ public class SoundsMatchModule implements MatchModule, Listener {
   private static final Sound RAINDROP_SOUND = new Sound("random.levelup", 1f, 1.5f);
 
   private void playSound(MatchPlayer player, Sound sound) {
-    if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ON)) {
+    if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL)) {
       player.playSound(sound);
     }
   }

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -981,9 +981,3 @@ commands.adminchat.noperms = You do not have permissions for admin chat, your ch
 
 # {0} = Name of target
 commands.message.noTarget = Could not find player '{0}' to send a message.
-
-# {0} = Name of party
-commands.chat.send.noParty = Could not find any party named {0}.
-
-commands.chat.send.notObs = You may only send messages to other teams while observing.
-commands.chat.send.finished = You are unable to send team chat messages at this time.

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -973,6 +973,17 @@ moderation.records.type = Type: {0}
 # {0} = Invalid target input
 commands.invalid.target = {0} has not joined the server yet.
 
-command.message.to = To
-command.message.from = From
+commands.message.to = To
+commands.message.from = From
 
+commands.message.noReply = Did not find a message to reply to, use /msg
+commands.adminchat.noperms = You do not have permissions for admin chat, your chat setting has now been reset
+
+# {0} = Name of target
+commands.message.noTarget = Could not find player '{0}' to send a message.
+
+# {0} = Name of party
+commands.chat.send.noParty = Could not find any party named {0}.
+
+commands.chat.send.notObs = You may only send messages to other teams while observing.
+commands.chat.send.finished = You are unable to send team chat messages at this time.

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -973,3 +973,6 @@ moderation.records.type = Type: {0}
 # {0} = Invalid target input
 commands.invalid.target = {0} has not joined the server yet.
 
+command.message.to = To
+command.message.from = From
+


### PR DESCRIPTION
# Chat and Sound improvements

This resolves #352 by allowing users to toggle their sound settings to disallow extra sound effects such as admin chat and reports. 

### All Changes Made:
- Adjusted setting values for sounds to `ALL`, `MESSAGES`, `NONE`.
  - `ALL` receive all sounds
  - `MESSAGES` only `/msg` sounds are played
  - `NONE` no sound effects play
- ~Color change for Admin chat to differentiate it from direct messages.~
- Changed DM formatting (see below)
- Lowered pitch for admin chat sound 
  -  New sound is just a tad bit different so should help tell the difference between different alerts
- Added a new `/say (team) (message)` command to allow staff to speak in team chats while observing. 


**Update: screenshot outdated, see below for new info.**

Signed-off-by: applenick <applenick@users.noreply.github.com>