### PR TITLE
Add sender feedback to /team force command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/commands/TeamCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/TeamCommands.java
@@ -7,15 +7,17 @@ import app.ashcon.intake.bukkit.parametric.annotation.Fallback;
 import app.ashcon.intake.parametric.annotation.Switch;
 import app.ashcon.intake.parametric.annotation.Text;
 import java.util.*;
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
+import tc.oc.util.bukkit.named.NameStyle;
 import tc.oc.util.bukkit.translations.AllTranslations;
 
 public class TeamCommands {
@@ -43,8 +45,14 @@ public class TeamCommands {
       desc = "Force a player onto a team",
       usage = "<player> [team]",
       perms = Permissions.JOIN_FORCE)
-  public static void force(Match match, TeamMatchModule tmm, Player player, @Text String teamName) {
+  public static void force(
+      CommandSender sender,
+      Match match,
+      TeamMatchModule tmm,
+      Player player,
+      @Text String teamName) {
     MatchPlayer matchPlayer = match.getPlayer(player);
+    Party oldParty = matchPlayer.getParty();
     if (teamName != null) {
       if (teamName.trim().toLowerCase().startsWith("obs")) {
         match.setParty(matchPlayer, match.getDefaultParty());
@@ -55,6 +63,14 @@ public class TeamCommands {
     } else {
       tmm.forceJoin(matchPlayer, null);
     }
+    sender.sendMessage(
+        new PersonalizedTranslatable(
+                "command.team.force.success",
+                matchPlayer.getStyledName(NameStyle.FANCY),
+                matchPlayer.getParty().getComponentName(),
+                oldParty.getComponentName())
+            .getPersonalizedText()
+            .color(ChatColor.GRAY));
   }
 
   @Command(

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -428,7 +428,8 @@ command.rotation.removeat.success = Successfully removed map at index {0} from t
 
 # {0} = user being forced
 # {1} = team being forced onto
-command.team.force.success = {0} successfully forced onto {1}
+# {2} = last team before force
+command.team.force.success = {0} forced onto {1} from {2}
 
 command.team.shuffle.success = Teams successfully shuffled.
 


### PR DESCRIPTION
# Add sender feedback to /team force command

Resolves #355 

Really simple fix which sends feedback when using the `/team force` command. I adjusted the format to also include the team the player was previously on. 

### Screenshot
Example of `/team force applenick3 Red`
![Screen Shot 2020-03-14 at 12 20 36 AM](https://user-images.githubusercontent.com/3377659/76677325-39553880-658a-11ea-8063-184781fc3c30.png)


Signed-off-by: applenick <applenick@users.noreply.github.com>