### PR TITLE
Fix /match not showing opposing obj completion

### DIFF
--- a/core/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
@@ -91,11 +91,11 @@ public abstract class SimpleGoal<T extends GoalDefinition> implements Goal<T> {
   }
 
   public ChatColor renderSidebarStatusColor(@Nullable Competitor competitor, Party viewer) {
-    return isCompleted(competitor) ? COLOR_COMPLETE : COLOR_INCOMPLETE;
+    return isCompleted() ? COLOR_COMPLETE : COLOR_INCOMPLETE;
   }
 
   public String renderSidebarStatusText(@Nullable Competitor competitor, Party viewer) {
-    return isCompleted(competitor) ? SYMBOL_COMPLETE : SYMBOL_INCOMPLETE;
+    return isCompleted() ? SYMBOL_COMPLETE : SYMBOL_INCOMPLETE;
   }
 
   public ChatColor renderSidebarLabelColor(@Nullable Competitor competitor, Party viewer) {

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -187,7 +187,7 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
 
   @Override
   public String renderSidebarStatusText(@Nullable Competitor competitor, Party viewer) {
-    if (this.isCompleted(competitor)) {
+    if (this.isCompleted()) {
       return SYMBOL_WOOL_COMPLETE;
     } else if (shouldShowTouched(competitor, viewer)) {
       return SYMBOL_WOOL_TOUCHED;


### PR DESCRIPTION
This should fix #275, where completed wool and destroyable objectives would not properly display as completed to opposing teams when using `/match` during the game.

Please let me know if I am missing anything here. Thanks!