### PR TITLE
Allow external plugins to manage tablist player order

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
@@ -43,9 +43,11 @@ public class MatchTabManager extends TabManager implements Listener {
       new DefaultMapAdapter<>(new FreeForAllTabEntry.Factory(), true);
 
   private BukkitTask renderTask;
+  private PlayerOrder.Factory playerOrderFactory;
 
   public MatchTabManager(Plugin plugin) {
     super(plugin, new MatchTabView.Factory(), null);
+    playerOrderFactory = new PlayerOrder.Factory();
   }
 
   public void disable() {
@@ -121,6 +123,10 @@ public class MatchTabManager extends TabManager implements Listener {
         break;
       }
     }
+  }
+
+  protected PlayerOrder.Factory getPlayerOrderFactory() {
+    return playerOrderFactory;
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
@@ -229,7 +229,7 @@ public class MatchTabView extends TabView implements ListeningTabView {
       this.match = event.getMatch();
       this.matchPlayer = event.getPlayer();
 
-      this.playerOrder = new PlayerOrder(this.matchPlayer);
+      this.playerOrder = getManager().getPlayerOrderFactory().getOrder(this.matchPlayer);
       this.teamOrder = new TeamOrder(this.matchPlayer);
 
       this.observerPlayers.clear();

--- a/core/src/main/java/tc/oc/pgm/tablist/PlayerOrder.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/PlayerOrder.java
@@ -8,10 +8,17 @@ import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 /**
- * The order that players are listed for a given viewer. Roughly speaking, the order is: 1. viewer
- * 2. friends 3. staff 4. other flair ranks 5. alphabetical
+ * The default order that players are listed for a given viewer. Roughly speaking, the order is: 1.
+ * viewer 2. friends 3. staff 4. other flair ranks 5. alphabetical
  */
 public class PlayerOrder implements Comparator<MatchPlayer> {
+  public static class Factory implements PlayerOrderFactory {
+    @Override
+    public PlayerOrder getOrder(MatchPlayer viewer) {
+      return new PlayerOrder(viewer);
+    }
+  }
+
   private final MatchPlayer viewer;
 
   PlayerOrder(MatchPlayer viewer) {

--- a/core/src/main/java/tc/oc/pgm/tablist/PlayerOrderFactory.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/PlayerOrderFactory.java
@@ -1,0 +1,7 @@
+package tc.oc.pgm.tablist;
+
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public interface PlayerOrderFactory {
+  PlayerOrder getOrder(MatchPlayer viewer);
+}


### PR DESCRIPTION
Signed-off-by: Meeples10 <mc.meeples10@gmail.com>

I realize that reflection is bad, and I would be happy to change it if anyone has a better idea.