### PR TITLE
Add alt account tracking

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -322,7 +322,10 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     node.registerCommands(new MapPoolCommands());
 
     // TODO: Community commands
-    node.registerCommands(new ModerationCommands(chat));
+    final ModerationCommands modCommands = new ModerationCommands(chat, getMatchManager());
+    node.registerCommands(modCommands);
+    registerEvents(modCommands);
+
     node.registerCommands(new ReportCommands());
 
     new BukkitIntake(this, graph).register();

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -973,3 +973,10 @@ moderation.records.type = Type: {0}
 # {0} = Invalid target input
 commands.invalid.target = {0} has not joined the server yet.
 
+# {0} = Name of new player
+# {1} = Name of recently banned player
+moderation.events.similarIP = {0} has a similar IP to banned player {1}.
+
+# {0} = Name of punisher
+# {1} = Time ago
+moderation.events.similarIP.hover = Banned by {0}, {1}


### PR DESCRIPTION
# Alt-Account tracking

This is a further improvement to the moderation commands and contains a new feature and a fix.

## Account Tracking & Notification 
PGM now will track recent bans that are handled and notify staff members when a similar IP joins.
Staff are notified with a simple message upon login of the similar IP. 

Basically this works by keeping a list of all ban punishments from since the server starts. I don’t see this as  major issue though, as this is more to help moderations in the moment. As in a short period of time after performing a punishment, when a banned player is most likely to attempt evading their ban.

## Screenshot:
![Screen Shot 2020-03-21 at 12 27 14 AM](https://user-images.githubusercontent.com/3377659/77244559-39c98100-6bd3-11ea-99ef-86faa51f009e.png)
As seen, the format is `[A] {new player} has a similar IP to banned player {banned player}.`

## Also: Fix for /offlineban
The offline ban command does not currently check if there are any matching targets online. Now the username is checked online and if found they will be kicked and have their ban cached as mentioned previously. 

## Feedback:
Let me know if there are any changes I can make to this feature. The only questionable decision I recall was making ModerationCommands a listener, I’m unsure if this violates any practice we were striving for. But if desired I can make a separate listener for the event, though I didn’t see it as that big of a deal. Let me know though!

 Also I thought of adding a new sound effect to notify staff members when this alert plays. If that’s something that most people like, I can look into adding it. Otherwise should be good to go 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>