### PR TITLE
Translation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PGM ![build](https://github.com/Electroid/PGM/workflows/build/badge.svg)
+PGM ![build](https://github.com/Electroid/PGM/workflows/build/badge.svg) [![Crowdin](https://badges.crowdin.net/pgm/localized.svg)](https://crowdin.com/project/pgm)
 ===
 
 The original PvP Game Manager for Minecraft.

--- a/core/src/main/java/tc/oc/pgm/api/chat/PlayerAudience.java
+++ b/core/src/main/java/tc/oc/pgm/api/chat/PlayerAudience.java
@@ -26,7 +26,9 @@ public class PlayerAudience extends CommandSenderAudience {
       Component title, Component subtitle, int inTicks, int stayTicks, int outTicks) {
     title = title == null ? new PersonalizedText("") : title;
     subtitle = subtitle == null ? new PersonalizedText("") : subtitle;
-    getPlayer().showTitle(title.render(), subtitle.render(), inTicks, stayTicks, outTicks);
+
+    Player player = getPlayer();
+    player.showTitle(title.render(player), subtitle.render(player), inTicks, stayTicks, outTicks);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -3,6 +3,8 @@ package tc.oc.pgm.api.map;
 import java.text.Normalizer;
 import java.util.Collection;
 import javax.annotation.Nullable;
+
+import org.bukkit.command.CommandSender;
 import tc.oc.util.Version;
 import tc.oc.util.bukkit.component.Component;
 import tc.oc.util.bukkit.named.MapNameStyle;
@@ -110,9 +112,10 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * Creates a component of the map name with styling
    *
    * @param style - the {@link MapNameStyle} to style name with
+   * @param viewer - the {@link CommandSender} viewer
    * @return A new component of the Map name
    */
-  Component getStyledMapName(MapNameStyle style);
+  Component getStyledMapName(MapNameStyle style, CommandSender viewer);
 
   @Override
   default int compareTo(MapInfo o) {

--- a/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -96,7 +96,7 @@ public class MapCommands {
       public String format(MapInfo map, int index) {
         return (index + 1)
             + ". "
-            + map.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS).toLegacyText();
+            + map.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, sender).toLegacyText();
       }
     }.display(audience, ImmutableSortedSet.copyOf(maps), page);
   }
@@ -264,7 +264,7 @@ public class MapCommands {
                 .translate(
                     "command.map.next.success",
                     sender,
-                    next.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS).toLegacyText()
+                    next.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, sender).toLegacyText()
                         + ChatColor.DARK_PURPLE));
   }
 

--- a/core/src/main/java/tc/oc/pgm/commands/MapPoolCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MapPoolCommands.java
@@ -98,7 +98,7 @@ public class MapPoolCommands {
         str +=
             ChatColor.RESET
                 + ""
-                + map.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS).toLegacyText();
+                + map.getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, sender).toLegacyText();
         return str;
       }
     }.display(audience, maps, page);

--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -95,7 +95,7 @@ public abstract class MatchCountdown extends Countdown {
     invalidateBossBar();
 
     if (showChat()) {
-      getMatch().sendMessage(formatText().toLegacyText());
+      getMatch().sendMessage(formatText());
     }
 
     if (showTitle()) {

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
@@ -63,7 +63,7 @@ public class CycleCountdown extends MatchCountdown {
               : new PersonalizedTranslatable("countdown.cycle.message.no_map", secs);
     }
 
-    return new PersonalizedText(cycleComponent, ChatColor.DARK_AQUA);
+    return cycleComponent.color(ChatColor.DARK_AQUA);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -48,12 +48,9 @@ public class MatchAnnouncer implements Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onMatchBegin(final MatchStartEvent event) {
     Match match = event.getMatch();
-    match.sendMessage(
-        new PersonalizedText(
-            new PersonalizedTranslatable("broadcast.matchStart"), ChatColor.GREEN));
+    match.sendMessage(new PersonalizedTranslatable("broadcast.matchStart").color(ChatColor.GREEN));
 
-    Component go =
-        new PersonalizedText(new PersonalizedTranslatable("broadcast.go"), ChatColor.GREEN);
+    Component go = new PersonalizedTranslatable("broadcast.go").color(ChatColor.GREEN);
     for (MatchPlayer player : match.getParticipants()) {
       player.showTitle(go, null, 0, 5, 15);
     }
@@ -82,17 +79,13 @@ public class MatchAnnouncer implements Listener {
           // Winner
           viewer.playSound(SOUND_MATCH_WIN);
           if (viewer.getParty() instanceof Team) {
-            subtitle =
-                new PersonalizedText(
-                    new PersonalizedTranslatable("broadcast.gameOver.teamWon"), ChatColor.GREEN);
+            subtitle = new PersonalizedTranslatable("broadcast.gameOver.teamWon").color(ChatColor.GREEN);
           }
         } else if (viewer.getParty() instanceof Competitor) {
           // Loser
           viewer.playSound(SOUND_MATCH_LOSE);
           if (viewer.getParty() instanceof Team) {
-            subtitle =
-                new PersonalizedText(
-                    new PersonalizedTranslatable("broadcast.gameOver.teamLost"), ChatColor.RED);
+            subtitle = new PersonalizedTranslatable("broadcast.gameOver.teamLost").color(ChatColor.RED);
           }
         } else {
           // Observer
@@ -126,7 +119,7 @@ public class MatchAnnouncer implements Listener {
     if (!authors.isEmpty()) {
       viewer.sendMessage(
           new PersonalizedText(" ", ChatColor.DARK_GRAY)
-              .extra(
+              .extra(viewer.getBukkit(),
                   new PersonalizedTranslatable(
                       "broadcast.welcomeMessage.createdBy",
                       TranslationUtils.nameList(NameStyle.FANCY, authors))));
@@ -137,10 +130,9 @@ public class MatchAnnouncer implements Listener {
 
   private void sendCurrentlyPlaying(MatchPlayer viewer) {
     viewer.sendMessage(
-        new PersonalizedTranslatable(
-                "broadcast.currentlyPlaying",
-                viewer.getMatch().getMap().getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS))
-            .getPersonalizedText()
-            .color(ChatColor.DARK_PURPLE));
+            new PersonalizedTranslatable(
+                    "broadcast.currentlyPlaying",
+                    viewer.getMatch().getMap().getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, viewer.getBukkit()))
+                    .color(ChatColor.DARK_PURPLE));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.bukkit.Difficulty;
+import org.bukkit.command.CommandSender;
 import org.jdom2.Element;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.map.MapInfo;
@@ -191,13 +192,13 @@ public class MapInfoImpl implements MapInfo {
   }
 
   @Override
-  public Component getStyledMapName(MapNameStyle style) {
+  public Component getStyledMapName(MapNameStyle style, @Nullable CommandSender viewer) {
     Component styledName = null;
     Component mapName = new PersonalizedText(getName());
     Component authors =
         new PersonalizedText(
             TranslationUtils.legacyList(
-                NullCommandSender.INSTANCE,
+                viewer,
                 (input) -> ChatColor.DARK_PURPLE + input,
                 (input) -> ChatColor.RED + input,
                 getAuthors().stream().map(Contributor::getName).collect(Collectors.toList())));

--- a/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
@@ -9,7 +9,6 @@ import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.countdowns.MatchCountdown;
 import tc.oc.pgm.timelimit.TimeLimitCountdown;
 import tc.oc.util.bukkit.component.Component;
-import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
 
 public class ModeChangeCountdown extends MatchCountdown implements Comparable<ModeChangeCountdown> {
@@ -53,12 +52,11 @@ public class ModeChangeCountdown extends MatchCountdown implements Comparable<Mo
 
   @Override
   protected Component formatText() {
-    return new PersonalizedText(
-        new PersonalizedTranslatable(
+    return new PersonalizedTranslatable(
             "match.objectiveMode.countdown",
             getMode().getComponentName(),
-            secondsRemaining(ChatColor.AQUA)),
-        ChatColor.DARK_AQUA);
+            secondsRemaining(ChatColor.AQUA))
+            .color(ChatColor.DARK_AQUA);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
@@ -6,7 +6,6 @@ import org.joda.time.Duration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.MatchCountdown;
 import tc.oc.util.bukkit.component.Component;
-import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
 
 public class RestartCountdown extends MatchCountdown {
@@ -18,13 +17,11 @@ public class RestartCountdown extends MatchCountdown {
   @Override
   protected Component formatText() {
     if (remaining.isLongerThan(Duration.ZERO)) {
-      return new PersonalizedText(
-          new PersonalizedTranslatable(
-              "broadcast.serverRestart.message", secondsRemaining(ChatColor.DARK_RED)),
-          ChatColor.AQUA);
+      return new PersonalizedTranslatable(
+              "broadcast.serverRestart.message", secondsRemaining(ChatColor.DARK_RED))
+              .color(ChatColor.AQUA);
     } else {
-      return new PersonalizedText(
-          new PersonalizedTranslatable("broadcast.serverRestart.kickMsg"), ChatColor.RED);
+      return new PersonalizedTranslatable("broadcast.serverRestart.kickMsg").color(ChatColor.RED);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -113,7 +113,7 @@ public class MapPoll {
 
     // Check if the winning map name's length suitable for the top title, otherwise subtitle
     boolean top = winner.getName().length() < TITLE_LENGTH_CUTOFF;
-    Component mapName = winner.getStyledMapName(MapNameStyle.COLOR).bold(true);
+    Component mapName = winner.getStyledMapName(MapNameStyle.COLOR, viewer.getBukkit()).bold(true);
 
     viewer.showTitle(
         top ? mapName : Components.blank(), top ? Components.blank() : mapName, 5, 60, 5);
@@ -129,7 +129,7 @@ public class MapPoll {
         new PersonalizedText("" + countVotes(votes.get(map)), ChatColor.YELLOW),
         new PersonalizedText("] "),
         map.getStyledMapName(
-            winner ? MapNameStyle.HIGHLIGHT_WITH_AUTHORS : MapNameStyle.COLOR_WITH_AUTHORS));
+            winner ? MapNameStyle.HIGHLIGHT_WITH_AUTHORS : MapNameStyle.COLOR_WITH_AUTHORS, viewer.getBukkit()));
   }
 
   public void sendBook(MatchPlayer viewer) {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -97,7 +97,7 @@ public abstract class Spawning extends Participating {
   }
 
   public void updateTitle() {
-    player.showTitle(getTitle(), new PersonalizedText(getSubtitle(), ChatColor.GREEN), 0, 3, 3);
+    player.showTitle(getTitle(), getSubtitle().color(ChatColor.GREEN), 0, 3, 3);
   }
 
   protected abstract Component getTitle();

--- a/core/src/main/java/tc/oc/pgm/start/HuddleCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/HuddleCountdown.java
@@ -22,10 +22,8 @@ public class HuddleCountdown extends PreMatchCountdown implements Listener {
 
   @Override
   protected Component formatText() {
-    return new PersonalizedText(
-        new PersonalizedTranslatable(
-            "countdown.huddle.message", secondsRemaining(ChatColor.DARK_RED)),
-        ChatColor.YELLOW);
+    return new PersonalizedTranslatable(
+            "countdown.huddle.message", secondsRemaining(ChatColor.DARK_RED)).color(ChatColor.YELLOW);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
@@ -9,7 +9,6 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.util.bukkit.component.Component;
-import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
 
 /** Countdown to team huddle, or match start if huddle is disabled */
@@ -37,10 +36,9 @@ public class StartCountdown extends PreMatchCountdown {
 
   @Override
   protected Component formatText() {
-    return new PersonalizedText(
-        new PersonalizedTranslatable(
-            "countdown.matchStart.message", secondsRemaining(ChatColor.DARK_RED)),
-        ChatColor.GREEN);
+    return new PersonalizedTranslatable(
+            "countdown.matchStart.message", secondsRemaining(ChatColor.DARK_RED))
+            .color(ChatColor.GREEN);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
@@ -30,7 +30,6 @@ import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.util.bukkit.bossbar.DynamicBossBar;
 import tc.oc.util.bukkit.component.Component;
-import tc.oc.util.bukkit.component.types.PersonalizedText;
 
 @ListenerScope(MatchScope.LOADED)
 public class StartMatchModule implements MatchModule, Listener {
@@ -139,7 +138,7 @@ public class StartMatchModule implements MatchModule, Listener {
     if (unreadyReasons.isEmpty()) {
       return null;
     } else {
-      return new PersonalizedText(unreadyReasons.iterator().next().getReason(), ChatColor.RED);
+      return unreadyReasons.iterator().next().getReason().color(ChatColor.RED);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
@@ -32,10 +32,9 @@ public class TimeLimitCountdown extends MatchCountdown {
 
   @Override
   protected Component formatText() {
-    return new PersonalizedText(
-        new PersonalizedTranslatable(
-            "match.timeRemaining", new PersonalizedText(colonTime(), urgencyColor())),
-        ChatColor.AQUA);
+    return new PersonalizedTranslatable(
+            "match.timeRemaining", new PersonalizedText(colonTime(), urgencyColor()))
+            .color(ChatColor.AQUA);
   }
 
   @Override

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,10 @@
+project_identifier: pgm
+api_key_env: CROWDIN_API_KEY
+preserve_hierarchy: false
+files:
+  - source: /util-bukkit/src/main/i18n/templates/*.properties
+    translation: /util-bukkit/src/main/i18n/translations/%file_name%_%locale_with_underscore%.%file_extension%
+    ignore:
+      - '**/server.properties'
+commit_message: Update %original_file_name% translations
+append_commit_message: false

--- a/util-bukkit/src/main/i18n/README.md
+++ b/util-bukkit/src/main/i18n/README.md
@@ -1,0 +1,13 @@
+Translations [![Crowdin](https://badges.crowdin.net/pgm/localized.svg)](https://crowdin.com/project/pgm)
+===
+
+All languages that are [supported by the Minecraft client](https://crowdin.net/project/minecraft) are supported by PGM.
+
+The original English string templates live in [strings.properties](./templates/strings.properties), and may be edited
+when making modifications to the project. Modifications to the English string templates will be automatically uploaded
+to [our CrowdIn project](https://crowdin.com/project/pgm) when a new commit is pushed to the `master` branch or any
+`feat/*` branch on the main PGM repo. Translations may then be submitted by the community. Once they are approved, they
+will be automatically PR'd back into the source branch on an hourly basis.
+
+**Note**: Please do not modify any *translation* files directly in this repo. Instead, translations should be submitted
+through [our CrowdIn project](https://crowdin.com/project/pgm), through the process described above.

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -763,7 +763,7 @@ match.flag.captureDenied.byFlag = {0} will be captured when {1} is dropped
 # {1} = singular / plural substitution
 # {2} = the team name
 match.score.scorebox = {0} scored {1} for {2}
-points.singularCompound = 1 point
+points.singularCompound = {0} point
 points.pluralCompound = {0} points
 
 # {0} = singular / plural substitution

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/component/Component.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/component/Component.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import tc.oc.util.bukkit.component.types.PersonalizedText;
 
@@ -124,17 +125,21 @@ public class Component implements PersonalizedComponent {
     return this;
   }
 
+  public Component extra(@Nullable CommandSender viewer, Component... extras) {
+    return this.extra(Arrays.asList(extras), viewer);
+  }
+
   public Component extra(Component... extras) {
-    return this.extra(Arrays.asList(extras));
+    return this.extra(null, extras);
   }
 
   public Component extra(String extra) {
     return this.extra(new PersonalizedText(extra));
   }
 
-  public Component extra(Collection<Component> extras) {
+  public Component extra(Collection<Component> extras, @Nullable CommandSender viewer) {
     List<BaseComponent> components = new ArrayList<>(extras.size());
-    for (Component extra : extras) components.add(extra.render());
+    for (Component extra : extras) components.add(extra.render(viewer));
     if (this.getExtra() == null) {
       this.setExtra(components);
     } else {

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/component/types/PersonalizedTranslatable.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/component/types/PersonalizedTranslatable.java
@@ -55,7 +55,10 @@ public class PersonalizedTranslatable extends Component {
       // Found a TranslatableComponent with one of our keys
       List<Component> with = new ArrayList<>(component.getWith().size());
       for (BaseComponent extra : component.getWith()) with.add(new Component(extra));
-      return new PersonalizedText(Components.format(pattern, with)).render(viewer);
+
+      BaseComponent finalComponent = new PersonalizedText(Components.format(pattern, with)).render(viewer);
+      Components.copyFormat(component, finalComponent);
+      return finalComponent;
     } else {
       // Fallback
       TranslatableComponent replacement = new TranslatableComponent(component);


### PR DESCRIPTION
This adds a CrowdIn configuration file for [our CrowdIn project](https://crowdin.com/project/pgm). I removed the integration with `Electroid/PGM` and linked it to `rmsy/PGM`, so that I could test that the integration was working smoothly. It just needs to be relinked to the correct repository, which can be done [here](https://crowdin.com/project/pgm/settings#integration), **after** this PR is merged. Once that's done, CrowdIn should automatically create a pull request to merge in the current approved translations from the various languages. As soon as that's merged, translations will work out-of-the-box.

Additionally, I fixed various rendering issues throughout PGM where translations were not being displayed. There are still a few sticklers (some error messages, `/map`, etc.), but this gets us probably 85% of the way there.

One issue I do need to figure out -- Spanish accents are not being rendered correctly, for some reason:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/406387/77276596-1103c300-6c89-11ea-946c-ab05affcb43a.png">

They are stored and encoded correctly in the output files, as far as I can tell. Not sure what's going on there.