### PR TITLE
Add a setter for MatchTabManager's PlayerOrderFactory

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.api.map;
 import java.text.Normalizer;
 import java.util.Collection;
 import javax.annotation.Nullable;
-
 import org.bukkit.command.CommandSender;
 import tc.oc.util.Version;
 import tc.oc.util.bukkit.component.Component;

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -79,13 +79,15 @@ public class MatchAnnouncer implements Listener {
           // Winner
           viewer.playSound(SOUND_MATCH_WIN);
           if (viewer.getParty() instanceof Team) {
-            subtitle = new PersonalizedTranslatable("broadcast.gameOver.teamWon").color(ChatColor.GREEN);
+            subtitle =
+                new PersonalizedTranslatable("broadcast.gameOver.teamWon").color(ChatColor.GREEN);
           }
         } else if (viewer.getParty() instanceof Competitor) {
           // Loser
           viewer.playSound(SOUND_MATCH_LOSE);
           if (viewer.getParty() instanceof Team) {
-            subtitle = new PersonalizedTranslatable("broadcast.gameOver.teamLost").color(ChatColor.RED);
+            subtitle =
+                new PersonalizedTranslatable("broadcast.gameOver.teamLost").color(ChatColor.RED);
           }
         } else {
           // Observer
@@ -119,7 +121,8 @@ public class MatchAnnouncer implements Listener {
     if (!authors.isEmpty()) {
       viewer.sendMessage(
           new PersonalizedText(" ", ChatColor.DARK_GRAY)
-              .extra(viewer.getBukkit(),
+              .extra(
+                  viewer.getBukkit(),
                   new PersonalizedTranslatable(
                       "broadcast.welcomeMessage.createdBy",
                       TranslationUtils.nameList(NameStyle.FANCY, authors))));
@@ -130,9 +133,12 @@ public class MatchAnnouncer implements Listener {
 
   private void sendCurrentlyPlaying(MatchPlayer viewer) {
     viewer.sendMessage(
-            new PersonalizedTranslatable(
-                    "broadcast.currentlyPlaying",
-                    viewer.getMatch().getMap().getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, viewer.getBukkit()))
-                    .color(ChatColor.DARK_PURPLE));
+        new PersonalizedTranslatable(
+                "broadcast.currentlyPlaying",
+                viewer
+                    .getMatch()
+                    .getMap()
+                    .getStyledMapName(MapNameStyle.COLOR_WITH_AUTHORS, viewer.getBukkit()))
+            .color(ChatColor.DARK_PURPLE));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -22,7 +22,6 @@ import tc.oc.pgm.map.contrib.PlayerContributor;
 import tc.oc.pgm.map.contrib.PseudonymContributor;
 import tc.oc.pgm.util.XMLUtils;
 import tc.oc.util.Version;
-import tc.oc.util.bukkit.chat.NullCommandSender;
 import tc.oc.util.bukkit.component.Component;
 import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;

--- a/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
@@ -56,7 +56,7 @@ public class ModeChangeCountdown extends MatchCountdown implements Comparable<Mo
             "match.objectiveMode.countdown",
             getMode().getComponentName(),
             secondsRemaining(ChatColor.AQUA))
-            .color(ChatColor.DARK_AQUA);
+        .color(ChatColor.DARK_AQUA);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
@@ -19,7 +19,7 @@ public class RestartCountdown extends MatchCountdown {
     if (remaining.isLongerThan(Duration.ZERO)) {
       return new PersonalizedTranslatable(
               "broadcast.serverRestart.message", secondsRemaining(ChatColor.DARK_RED))
-              .color(ChatColor.AQUA);
+          .color(ChatColor.AQUA);
     } else {
       return new PersonalizedTranslatable("broadcast.serverRestart.kickMsg").color(ChatColor.RED);
     }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -129,7 +129,8 @@ public class MapPoll {
         new PersonalizedText("" + countVotes(votes.get(map)), ChatColor.YELLOW),
         new PersonalizedText("] "),
         map.getStyledMapName(
-            winner ? MapNameStyle.HIGHLIGHT_WITH_AUTHORS : MapNameStyle.COLOR_WITH_AUTHORS, viewer.getBukkit()));
+            winner ? MapNameStyle.HIGHLIGHT_WITH_AUTHORS : MapNameStyle.COLOR_WITH_AUTHORS,
+            viewer.getBukkit()));
   }
 
   public void sendBook(MatchPlayer viewer) {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -12,7 +12,6 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.spawns.Spawn;
 import tc.oc.pgm.spawns.SpawnMatchModule;
 import tc.oc.util.bukkit.component.Component;
-import tc.oc.util.bukkit.component.types.PersonalizedText;
 import tc.oc.util.bukkit.component.types.PersonalizedTranslatable;
 
 /** Player is waiting to spawn as a participant */

--- a/core/src/main/java/tc/oc/pgm/start/HuddleCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/HuddleCountdown.java
@@ -23,7 +23,8 @@ public class HuddleCountdown extends PreMatchCountdown implements Listener {
   @Override
   protected Component formatText() {
     return new PersonalizedTranslatable(
-            "countdown.huddle.message", secondsRemaining(ChatColor.DARK_RED)).color(ChatColor.YELLOW);
+            "countdown.huddle.message", secondsRemaining(ChatColor.DARK_RED))
+        .color(ChatColor.YELLOW);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
@@ -38,7 +38,7 @@ public class StartCountdown extends PreMatchCountdown {
   protected Component formatText() {
     return new PersonalizedTranslatable(
             "countdown.matchStart.message", secondsRemaining(ChatColor.DARK_RED))
-            .color(ChatColor.GREEN);
+        .color(ChatColor.GREEN);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
@@ -43,7 +43,7 @@ public class MatchTabManager extends TabManager implements Listener {
       new DefaultMapAdapter<>(new FreeForAllTabEntry.Factory(), true);
 
   private BukkitTask renderTask;
-  private PlayerOrder.Factory playerOrderFactory;
+  private PlayerOrderFactory playerOrderFactory;
 
   public MatchTabManager(Plugin plugin) {
     super(plugin, new MatchTabView.Factory(), null);
@@ -125,8 +125,12 @@ public class MatchTabManager extends TabManager implements Listener {
     }
   }
 
-  protected PlayerOrder.Factory getPlayerOrderFactory() {
+  protected PlayerOrderFactory getPlayerOrderFactory() {
     return playerOrderFactory;
+  }
+
+  public void setPlayerOrderFactory(PlayerOrderFactory factory) {
+    this.playerOrderFactory = factory;
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
@@ -34,7 +34,7 @@ public class TimeLimitCountdown extends MatchCountdown {
   protected Component formatText() {
     return new PersonalizedTranslatable(
             "match.timeRemaining", new PersonalizedText(colonTime(), urgencyColor()))
-            .color(ChatColor.AQUA);
+        .color(ChatColor.AQUA);
   }
 
   @Override

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/component/Component.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/component/Component.java
@@ -14,7 +14,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import tc.oc.util.bukkit.component.types.PersonalizedText;
 

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/component/types/PersonalizedTranslatable.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/component/types/PersonalizedTranslatable.java
@@ -56,7 +56,8 @@ public class PersonalizedTranslatable extends Component {
       List<Component> with = new ArrayList<>(component.getWith().size());
       for (BaseComponent extra : component.getWith()) with.add(new Component(extra));
 
-      BaseComponent finalComponent = new PersonalizedText(Components.format(pattern, with)).render(viewer);
+      BaseComponent finalComponent =
+          new PersonalizedText(Components.format(pattern, with)).render(viewer);
       Components.copyFormat(component, finalComponent);
       return finalComponent;
     } else {


### PR DESCRIPTION
Signed-off-by: Meeples10 <mc.meeples10@gmail.com>

I forgot to actually add a setter for `MatchTabManager`'s `PlayerOrderFactory`, which was the entire purpose of my previous PR.

I am aware that files were changed other than `MatchTabManager` - those were only changed when running the formatter.