### PR TITLE
Fix loading of UTF-8 translations

### DIFF
--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/translations/provider/TranslationProvider.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/translations/provider/TranslationProvider.java
@@ -12,12 +12,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import tc.oc.util.bukkit.translations.Locales;
+import tc.oc.util.translate.UTF8Control;
 
 /** A class retrieves translations from a {@link ResourceBundle} */
 @SuppressWarnings("UnstableApiUsage")
 public class TranslationProvider {
 
   private final LoadingCache<Locale, Map<String, String>> cachedLocales;
+  private final UTF8Control control = new UTF8Control();
   private String name;
 
   public TranslationProvider(String name) {
@@ -98,7 +100,7 @@ public class TranslationProvider {
    * @return {@link Map} of translations
    */
   public Map<String, String> getTranslations(Locale locale) {
-    ResourceBundle bundle = ResourceBundle.getBundle(getName(), locale);
+    ResourceBundle bundle = ResourceBundle.getBundle(getName(), locale, this.control);
     return Collections.list(bundle.getKeys()).stream()
         .map(key -> new SimpleImmutableEntry<>(key, bundle.getString(key)))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));

--- a/util-bukkit/src/main/java/tc/oc/util/bukkit/translations2/MessageFormatProvider.java
+++ b/util-bukkit/src/main/java/tc/oc/util/bukkit/translations2/MessageFormatProvider.java
@@ -7,6 +7,8 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+import tc.oc.util.translate.UTF8Control;
+
 import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.Locale;
@@ -24,6 +26,7 @@ public class MessageFormatProvider {
   private final Locale defaultLocale;
   private final LoadingCache<Locale, Locale> localeCache;
   private final Table<String, Locale, MessageFormat> formatTable;
+  private final UTF8Control control = new UTF8Control();
 
   public MessageFormatProvider(@Nullable String resourceName, Locale defaultLocale) {
     this.defaultLocale = checkNotNull(defaultLocale);
@@ -44,7 +47,7 @@ public class MessageFormatProvider {
       try {
         final String path =
             resourceName == null || resourceName.isEmpty() ? lang : resourceName + "_" + lang;
-        bundle = ResourceBundle.getBundle(path, locale);
+        bundle = ResourceBundle.getBundle(path, locale, this.control);
       } catch (MissingResourceException e) {
         continue;
       }

--- a/util/src/main/java/tc/oc/util/translate/UTF8Control.java
+++ b/util/src/main/java/tc/oc/util/translate/UTF8Control.java
@@ -1,0 +1,51 @@
+package tc.oc.util.translate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+
+/**
+ * A {@link java.util.ResourceBundle.Control} implementation which allows reading of .properties files encoded with UTF-8.
+ *
+ * See https://stackoverflow.com/a/4660195 for more details.
+ */
+public class UTF8Control extends ResourceBundle.Control {
+    public ResourceBundle newBundle
+            (String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+            throws IllegalAccessException, InstantiationException, IOException
+    {
+        // The below is a copy of the default implementation.
+        String bundleName = toBundleName(baseName, locale);
+        String resourceName = toResourceName(bundleName, "properties");
+        ResourceBundle bundle = null;
+        InputStream stream = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+        if (stream != null) {
+            try {
+                // Only this line is changed to make it to read properties files as UTF-8.
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            } finally {
+                stream.close();
+            }
+        }
+        return bundle;
+    }
+}


### PR DESCRIPTION
This fixes the issue highlighted in #370 where UTF-8 translations are loaded as  ISO-8859-1. This causes them to appear incorrectly in-game.