### PR TITLE
Small fixes for match stats

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
@@ -37,7 +37,7 @@ public class StatsMatchModule implements MatchModule, Listener {
   private final Map<UUID, PlayerStats> allPlayerStats = new HashMap<>();
   // Since Bukkit#getOfflinePlayer reads the cached user files, and those files have an expire date
   // + will be wiped if X amount of players join, we need a seperate cache for players with stats
-  private final Map<UUID, Player> cachedPlayers = new HashMap<>();
+  private final Map<UUID, String> cachedUsernames = new HashMap<>();
 
   public StatsMatchModule(Match match) {
     this.match = match;
@@ -131,6 +131,9 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   @EventHandler
   public void onMatchEnd(MatchFinishEvent event) {
+
+    if (allPlayerStats.isEmpty()) return;
+
     Map<UUID, Integer> allKills = new HashMap<>();
     Map<UUID, Integer> allKillstreaks = new HashMap<>();
     Map<UUID, Integer> allDeaths = new HashMap<>();
@@ -183,13 +186,13 @@ public class StatsMatchModule implements MatchModule, Listener {
   public void onPlayerLeave(PlayerQuitEvent event) {
     Player player = event.getPlayer();
     if (allPlayerStats.containsKey(player.getUniqueId()))
-      cachedPlayers.put(player.getUniqueId(), player);
+      cachedUsernames.put(player.getUniqueId(), player.getName());
   }
 
   @EventHandler
   public void onPlayerJoin(PlayerJoinEvent event) {
     UUID playerUUID = event.getPlayer().getUniqueId();
-    cachedPlayers.remove(playerUUID);
+    cachedUsernames.remove(playerUUID);
   }
 
   private Map.Entry<UUID, Integer> sortStats(Map<UUID, Integer> map) {
@@ -219,10 +222,10 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   private PersonalizedText playerName(UUID playerUUID) {
     if (Bukkit.getPlayer(playerUUID) == null) {
-      if (cachedPlayers.get(playerUUID) == null) {
+      if (cachedUsernames.get(playerUUID) == null) {
         return new PersonalizedText("Unknown", ChatColor.MAGIC, ChatColor.BLACK);
       }
-      return new PersonalizedText(cachedPlayers.get(playerUUID).getName(), ChatColor.DARK_AQUA);
+      return new PersonalizedText(cachedUsernames.get(playerUUID), ChatColor.DARK_AQUA);
     }
     return new PersonalizedText(match.getPlayer(playerUUID).getBukkit().getDisplayName());
   }

--- a/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
@@ -68,7 +68,7 @@ public class StatsMatchModule implements MatchModule, Listener {
       if (deaths == 0) {
         kd = "0";
       } else {
-        kd = decimalFormatKd.format(kills / deaths);
+        kd = decimalFormatKd.format(kills / (double) deaths);
       }
       return new Component(
           new PersonalizedTranslatable(

--- a/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
@@ -72,7 +72,7 @@ public class StatsMatchModule implements MatchModule, Listener {
     Component getBasicStatsMessage() {
       String kd;
       if (deaths == 0) {
-        kd = "0";
+        kd = Double.toString(kills);
       } else {
         kd = decimalFormatKd.format(kills / (double) deaths);
       }

--- a/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
@@ -157,20 +157,26 @@ public class StatsMatchModule implements MatchModule, Listener {
         (bestBowshot.getValue() == 1) ? "stats.bowshot.block" : "stats.bowshot.blocks";
     Component bowshotMessage = getMessage(bowMessageKey, bestBowshot, ChatColor.YELLOW);
 
-    for (MatchPlayer viewer : match.getPlayers()) {
-      viewer.sendMessage(
-          Components.fromLegacyText(
-              ComponentUtils.horizontalLineHeading(
-                  ChatColor.YELLOW
-                      + AllTranslations.get().translate("stats.best", viewer.getBukkit()),
-                  ChatColor.WHITE,
-                  ComponentUtils.MAX_CHAT_WIDTH)));
+    match.getScheduler(MatchScope.LOADED).runTaskLater(
+            20 * 6, //NOTE: This is 1 second after the votebook appears
+            () -> {
+      for (MatchPlayer viewer : match.getPlayers()) {
+        viewer.sendMessage(
+                Components.fromLegacyText(
+                        ComponentUtils.horizontalLineHeading(
+                                ChatColor.YELLOW
+                                        + AllTranslations.get().translate("stats.best", viewer.getBukkit()),
+                                ChatColor.WHITE,
+                                ComponentUtils.MAX_CHAT_WIDTH)));
 
-      viewer.sendMessage(killMessage);
-      viewer.sendMessage(killstreakMessage);
-      viewer.sendMessage(deathMessage);
-      if (bestBowshot.getValue() != 0) viewer.sendMessage(bowshotMessage);
-    }
+        viewer.sendMessage(killMessage);
+        viewer.sendMessage(killstreakMessage);
+        viewer.sendMessage(deathMessage);
+        if (bestBowshot.getValue() != 0) viewer.sendMessage(bowshotMessage);
+        }
+      }
+    );
+
   }
 
   @EventHandler
@@ -207,7 +213,7 @@ public class StatsMatchModule implements MatchModule, Listener {
         new PersonalizedTranslatable(
                 messageKey,
                 playerName(mapEntry.getKey()),
-                new PersonalizedText(Integer.toString(mapEntry.getValue()), color).render())
+                new PersonalizedText(Integer.toString(mapEntry.getValue()), color).bold(true).render())
             .render());
   }
 

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -1002,7 +1002,7 @@ stats.deaths = Deaths: {0} : {1}
 stats.bowshot.block = Longest bowshot: {0} : {1} block
 stats.bowshot.blocks = Longest bowshot: {0} : {1} blocks
 
-stats.best = Best stats this match
+stats.best = Top stats this match
 
 stats.current = Current stats
 


### PR DESCRIPTION
Fix list as of last commit:
-Fix formatting so KD includes up to two decimals.
-Change "stats.best" into "Top stats this match"
-Fix an issue with offline players having the best results resulting in an error for invalid UUIDs
-Cover for NPE when match is ended without any playerstats
Signed-off-by: KingOfSquares <simonmorland@gmail.com>