### PR TITLE
Add sound to custom projectile impact

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -19,6 +19,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.projectile.EntityLaunchEvent;
 import tc.oc.util.bukkit.chat.Sound;
@@ -134,7 +135,10 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
           Projectile customProjectile = (Projectile) projectile;
           if (customProjectile.getShooter() instanceof Player) {
             Player bukkitShooter = (Player) customProjectile.getShooter();
-            SoundsMatchModule.playSound(match.getPlayer(bukkitShooter), PROJECTILE_SOUND);
+            MatchPlayer shooter = match.getPlayer(bukkitShooter);
+            if (shooter != null) {
+              shooter.playSound(PROJECTILE_SOUND);
+            }
           }
         }
       }

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -5,6 +5,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,6 +21,7 @@ import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.projectile.EntityLaunchEvent;
+import tc.oc.util.bukkit.chat.Sound;
 import tc.oc.util.bukkit.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -29,6 +31,8 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
   private final Class<? extends Entity> cls;
   private final float velocityMod;
   private final Set<PotionEffect> potionEffects;
+
+  private static final Sound PROJECTILE_SOUND = new Sound("random.successful_hit", 0.18f, 0.45f);
 
   public ModifyBowProjectileMatchModule(
       Match match, Class<? extends Entity> cls, float velocityMod, Set<PotionEffect> effects) {
@@ -122,6 +126,16 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
           velocity.setZ(
               velocity.getZ() + projectileVelocity.getZ() * knockback * 0.6 / horizontalSpeed);
           event.getEntity().setVelocity(velocity);
+        }
+
+        // If the projectile is not an arrow, play an impact sound.
+        if (event.getEntity() instanceof Player
+            && (projectile instanceof Projectile && !(projectile instanceof Arrow))) {
+          Projectile customProjectile = (Projectile) projectile;
+          if (customProjectile.getShooter() instanceof Player) {
+            Player bukkitShooter = (Player) customProjectile.getShooter();
+            SoundsMatchModule.playSound(match.getPlayer(bukkitShooter), PROJECTILE_SOUND);
+          }
         }
       }
 

--- a/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
@@ -33,7 +33,7 @@ public class SoundsMatchModule implements MatchModule, Listener {
 
   private static final Sound RAINDROP_SOUND = new Sound("random.levelup", 1f, 1.5f);
 
-  private void playSound(MatchPlayer player, Sound sound) {
+  public static void playSound(MatchPlayer player, Sound sound) {
     if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL)) {
       player.playSound(sound);
     }

--- a/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/SoundsMatchModule.java
@@ -33,7 +33,7 @@ public class SoundsMatchModule implements MatchModule, Listener {
 
   private static final Sound RAINDROP_SOUND = new Sound("random.levelup", 1f, 1.5f);
 
-  public static void playSound(MatchPlayer player, Sound sound) {
+  private void playSound(MatchPlayer player, Sound sound) {
     if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL)) {
       player.playSound(sound);
     }


### PR DESCRIPTION
# Custom projectile sounds 🏹 
I was playing a match of Glacial Impact earlier and noticed that custom projectiles (snowballs) did not play the very helpful _ding_ when impacting a target. 

This PR makes it so the same _ding_ played for arrows, also play for custom projectiles.

I don’t believe there is much to improve upon, but if there is let me know. Otherwise should be good to go 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>