### PR TITLE
Add a line in /map showing which pools a map is in, if any.

### DIFF
--- a/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -21,6 +22,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.map.MapInfo;
@@ -28,6 +30,8 @@ import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.commands.annotations.Text;
+import tc.oc.pgm.rotation.MapPool;
+import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.util.PrettyPaginatedResult;
 import tc.oc.util.bukkit.chat.Audience;
 import tc.oc.util.bukkit.component.Component;
@@ -192,6 +196,16 @@ public class MapCommands {
     }
 
     audience.sendMessage(createTagsComponent(map.getTags()));
+
+    if (PGM.get().getMapOrder() instanceof MapPoolManager) {
+      List<MapPool> mapPools = ((MapPoolManager) PGM.get().getMapOrder()).contains(map);
+      if (!mapPools.isEmpty()) {
+        audience.sendMessage(
+            new PersonalizedText(
+                mapInfoLabel("command.map.mapInfo.containedInMapPools"),
+                createContainedInMapPoolsComponent(mapPools).bold(false)));
+      }
+    }
   }
 
   private Component createTagsComponent(Collection<MapTag> tags) {
@@ -244,6 +258,17 @@ public class MapCommands {
             ChatColor.GRAY);
 
     return total.extra(" ").extra(verbose);
+  }
+
+  private Component createContainedInMapPoolsComponent(List<MapPool> mapPools) {
+    PersonalizedText pools = new PersonalizedText();
+    int iteration = 1;
+    for (MapPool mapPool : mapPools) {
+      pools.extra(mapPool.getName());
+      if (mapPools.size() > iteration) pools.extra(", ");
+      iteration++;
+    }
+    return new PersonalizedText(pools, ChatColor.GOLD);
   }
 
   @Command(

--- a/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -198,12 +197,17 @@ public class MapCommands {
     audience.sendMessage(createTagsComponent(map.getTags()));
 
     if (PGM.get().getMapOrder() instanceof MapPoolManager) {
-      List<MapPool> mapPools = ((MapPoolManager) PGM.get().getMapOrder()).contains(map);
+      String mapPools =
+          ((MapPoolManager) PGM.get().getMapOrder())
+              .getMapPools().stream()
+                  .filter(pool -> pool.getMaps().contains(map))
+                  .map(MapPool::getName)
+                  .collect(Collectors.joining(", "));
       if (!mapPools.isEmpty()) {
         audience.sendMessage(
             new PersonalizedText(
-                mapInfoLabel("command.map.mapInfo.containedInMapPools"),
-                createContainedInMapPoolsComponent(mapPools).bold(false)));
+                mapInfoLabel("command.map.mapInfo.pools"),
+                new PersonalizedText(mapPools).color(ChatColor.GOLD).bold(false)));
       }
     }
   }
@@ -258,17 +262,6 @@ public class MapCommands {
             ChatColor.GRAY);
 
     return total.extra(" ").extra(verbose);
-  }
-
-  private Component createContainedInMapPoolsComponent(List<MapPool> mapPools) {
-    PersonalizedText pools = new PersonalizedText();
-    int iteration = 1;
-    for (MapPool mapPool : mapPools) {
-      pools.extra(mapPool.getName());
-      if (mapPools.size() > iteration) pools.extra(", ");
-      iteration++;
-    }
-    return new PersonalizedText(pools, ChatColor.GOLD);
   }
 
   @Command(

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -152,4 +152,16 @@ public class MapPoolManager implements MapOrder {
 
     activeMapPool.matchEnded(match);
   }
+
+  /**
+   * Checks all loaded {@link MapPool}s for a given {@link MapInfo} and returns all {@link MapPool}s
+   * that contains it
+   */
+  public List<MapPool> contains(MapInfo map) {
+    List<MapPool> containedIn = new ArrayList<>();
+    for (MapPool mapPool : this.mapPools) {
+      if (mapPool.getMaps().contains(map)) containedIn.add(mapPool);
+    }
+    return containedIn;
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -152,16 +152,4 @@ public class MapPoolManager implements MapOrder {
 
     activeMapPool.matchEnded(match);
   }
-
-  /**
-   * Checks all loaded {@link MapPool}s for a given {@link MapInfo} and returns all {@link MapPool}s
-   * that contains it
-   */
-  public List<MapPool> contains(MapInfo map) {
-    List<MapPool> containedIn = new ArrayList<>();
-    for (MapPool mapPool : this.mapPools) {
-      if (mapPool.getMaps().contains(map)) containedIn.add(mapPool);
-    }
-    return containedIn;
-  }
 }

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -547,7 +547,7 @@ command.map.mapInfo.sourceCode.tip = View the XML code that controls this map
 command.map.mapInfo.proto = Proto
 command.map.mapInfo.source = Source
 command.map.mapInfo.folder = Folder
-command.map.mapInfo.containedInMapPools = Pools
+command.map.mapInfo.pools = Pools
 
 
 command.pools.noPoolMatch = No map pools matched query.

--- a/util-bukkit/src/main/i18n/templates/strings.properties
+++ b/util-bukkit/src/main/i18n/templates/strings.properties
@@ -547,6 +547,7 @@ command.map.mapInfo.sourceCode.tip = View the XML code that controls this map
 command.map.mapInfo.proto = Proto
 command.map.mapInfo.source = Source
 command.map.mapInfo.folder = Folder
+command.map.mapInfo.containedInMapPools = Pools
 
 
 command.pools.noPoolMatch = No map pools matched query.


### PR DESCRIPTION
Closes #257 
Title. Looks like this:
2 or more pools will display like this
![2020-03-26_20 24 52](https://user-images.githubusercontent.com/19822231/77688193-f0e14600-6f9f-11ea-8d13-8d22a757c844.png)

1 pool will display like this
![2020-03-26_20 24 31](https://user-images.githubusercontent.com/19822231/77688190-f048af80-6f9f-11ea-8757-6488700c2187.png)

How it looks if map is in no pools
![2020-03-26_20 07 06](https://user-images.githubusercontent.com/19822231/77688186-ede65580-6f9f-11ea-8b95-0f702ccc6d77.png)







Signed-off-by: KingOfSquares <simonmorland@gmail.com>