### PR TITLE
Freeze world after match finish

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -31,6 +31,7 @@ import org.bukkit.plugin.Plugin;
 import tc.oc.pgm.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.match.MatchScope;
@@ -292,6 +293,14 @@ public class PGMListener implements Listener {
         .getMatch()
         .getWorld()
         .setGameRuleValue(GameRule.DO_DAYLIGHT_CYCLE.getValue(), Boolean.toString(false));
+  }
+
+  @EventHandler
+  public void freezeWorld(final BlockTransformEvent event) {
+    Match match = this.mm.getMatch(event.getWorld());
+    if (match != null && match.isFinished()) {
+      event.setCancelled(true);
+    }
   }
 
   @EventHandler


### PR DESCRIPTION
The world should freeze after completion of a match, so liquids don't leak further and TNT that has been ignited but not yet exploded does not cause any more damage. Fixes #92. 

My first PR to this codebase so let me know if I implemented this the right way, feedback is welcome. 