### PR TITLE
Add clickable player name in reports command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -123,7 +123,7 @@ public class ReportCommands {
         new Report(
             player.getName(),
             reason,
-            accused.getStyledName(NameStyle.CONCISE),
+            accused.getStyledName(NameStyle.FANCY),
             matchPlayer.getStyledName(NameStyle.CONCISE)));
 
     final Component prefixedComponent =
@@ -209,24 +209,23 @@ public class ReportCommands {
     new PrettyPaginatedComponentResults<Report>(formattedHeader, perPage) {
       @Override
       public Component format(Report data, int index) {
+
+        Component reporter =
+            new PersonalizedTranslatable("moderation.reports.hover", data.getSenderName())
+                .color(ChatColor.GRAY);
+
         Component timeAgo =
             PeriodFormats.relativePastApproximate(
                     org.joda.time.Instant.ofEpochMilli(data.getTimeSent().toEpochMilli()))
                 .color(ChatColor.DARK_AQUA);
-        Component hover =
-            new PersonalizedTranslatable("moderation.reports.hover", data.getSenderName())
-                .getPersonalizedText()
-                .color(ChatColor.GRAY);
 
-        Component formatted =
-            new PersonalizedText(
-                timeAgo,
-                new PersonalizedText(": ").color(ChatColor.GRAY),
-                data.getTargetName(),
-                new PersonalizedText(" « ").color(ChatColor.YELLOW),
-                new PersonalizedText(data.getReason()).italic(true).color(ChatColor.WHITE));
-
-        return formatted.hoverEvent(Action.SHOW_TEXT, hover.render(sender));
+        return new PersonalizedText(
+            new PersonalizedText(timeAgo.render(sender))
+                .hoverEvent(Action.SHOW_TEXT, reporter.render(sender)),
+            new PersonalizedText(": ").color(ChatColor.GRAY),
+            data.getTargetName(),
+            new PersonalizedText(" « ").color(ChatColor.YELLOW),
+            new PersonalizedText(data.getReason()).italic(true).color(ChatColor.WHITE));
       }
     }.display(audience, reportList, page);
   }


### PR DESCRIPTION
Allow the player names in `/reports` to be clicked to teleport.

The existing hover of who reported the player is now on hover of the timestamp.
Hovering on the player name will bring up the regular teleport tooltip.

![image](https://user-images.githubusercontent.com/8608892/78472885-3fc37400-7734-11ea-9d07-529f40235d46.png)

Had a bit of a faff getting the hover text to render on the time ago component but the code works. Happy to make modifications and carry out testing as I'm not sure if the multiple `render` calls are necessary.

Signed-off-by: Pugzy <pugzy@mail.com>