### PR TITLE
Fix projectile sound

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -136,7 +136,7 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
           if (customProjectile.getShooter() instanceof Player) {
             Player bukkitShooter = (Player) customProjectile.getShooter();
             MatchPlayer shooter = match.getPlayer(bukkitShooter);
-            if (shooter != null) {
+            if (shooter != null && event.getEntity() != null) {
               shooter.playSound(PROJECTILE_SOUND);
             }
           }


### PR DESCRIPTION
# Fix projectile sounds when impacting blocks 🔔 

It was brought to my attention that custom projectiles play the “ding” upon impact of not only players, but blocks. 

This quick fix should resolve that issue, I tested on Ozone to ensure and the “ding” no longer plays when impacting blocks. Sorry for not catching this in the original testing. 

Thanks to ocktick for alerting me of this issue. 👏 

Signed-off-by: applenick <applenick@users.noreply.github.com>