### PR TITLE
Introduce map-activity to the Datastore

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -180,7 +180,9 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     matchManager = new MatchManagerImpl(logger);
 
     if (Config.MapPools.areEnabled()) {
-      mapOrder = new MapPoolManager(logger, new File(getDataFolder(), Config.MapPools.getPath()));
+      mapOrder =
+          new MapPoolManager(
+              logger, new File(getDataFolder(), Config.MapPools.getPath()), datastore);
     } else {
       mapOrder = new RandomMapOrder();
     }

--- a/core/src/main/java/tc/oc/pgm/api/Datastore.java
+++ b/core/src/main/java/tc/oc/pgm/api/Datastore.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.api;
 
 import java.util.UUID;
+import tc.oc.pgm.api.map.PoolActivity;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
 
@@ -22,4 +23,12 @@ public interface Datastore {
    * @return A {@link Settings}.
    */
   Settings getSettings(UUID uuid);
+
+  /**
+   * Get the activity related to a defined map pool.
+   *
+   * @param poolName The name of a defined map pool.
+   * @return A {@link PoolActivity}.
+   */
+  PoolActivity getPoolActivity(String poolName);
 }

--- a/core/src/main/java/tc/oc/pgm/api/Datastore.java
+++ b/core/src/main/java/tc/oc/pgm/api/Datastore.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.api;
 
 import java.util.UUID;
-import tc.oc.pgm.api.map.PoolActivity;
+import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
 
@@ -28,7 +28,7 @@ public interface Datastore {
    * Get the activity related to a defined map pool.
    *
    * @param poolName The name of a defined map pool.
-   * @return A {@link PoolActivity}.
+   * @return A {@link MapActivity}.
    */
-  PoolActivity getPoolActivity(String poolName);
+  MapActivity getMapActivity(String poolName);
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/MapActivity.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapActivity.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.api.map;
 import javax.annotation.Nullable;
 
 /* Represents data related to persisting map pool info between server restarts */
-public interface PoolActivity {
+public interface MapActivity {
 
   /**
    * Get the name of the map pool.
@@ -17,21 +17,21 @@ public interface PoolActivity {
    *
    * @return The name of a map
    */
-  public String getNextMap();
+  public String getMapName();
 
   /**
    * Whether this map pool was the last active. If the map pool was the last active, it will be
    * resumed upon server restart.
    *
-   * @return Whether the map pool was last active
+   * @return Whether the map pool is active
    */
-  public boolean isLastActive();
+  public boolean isActive();
 
   /**
-   * Updates the map pool activity in the {@link Datastore}
+   * Updates the map activity in the {@link Datastore}
    *
-   * @param nextMap Name of next map if rotation based.
-   * @param active If this pool is the currently active one
+   * @param nextMap Name of next map (if rotation based).
+   * @param active If this pool is currently active.
    */
-  public void updatePool(@Nullable String nextMap, boolean active);
+  public void update(@Nullable String nextMap, boolean active);
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/PoolActivity.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/PoolActivity.java
@@ -1,0 +1,37 @@
+package tc.oc.pgm.api.map;
+
+import javax.annotation.Nullable;
+
+/* Represents data related to persisting map pool info between server restarts */
+public interface PoolActivity {
+
+  /**
+   * Get the name of the map pool.
+   *
+   * @return The name of the map pool
+   */
+  public String getPoolName();
+
+  /**
+   * For rotation based pools, will be the map that is resumed upon server restart.
+   *
+   * @return The name of a map
+   */
+  public String getNextMap();
+
+  /**
+   * Whether this map pool was the last active. If the map pool was the last active, it will be
+   * resumed upon server restart.
+   *
+   * @return Whether the map pool was last active
+   */
+  public boolean isLastActive();
+
+  /**
+   * Updates the map pool activity in the {@link Datastore}
+   *
+   * @param nextMap Name of next map if rotation based.
+   * @param active If this pool is the currently active one
+   */
+  public void updatePool(@Nullable String nextMap, boolean active);
+}

--- a/core/src/main/java/tc/oc/pgm/db/DatastoreCacheImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/DatastoreCacheImpl.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.bukkit.Bukkit;
 import tc.oc.pgm.api.Datastore;
+import tc.oc.pgm.api.map.PoolActivity;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
 
@@ -15,6 +16,7 @@ public class DatastoreCacheImpl implements Datastore {
 
   private final LoadingCache<UUID, Username> usernames;
   private final LoadingCache<UUID, Settings> settings;
+  private final LoadingCache<String, PoolActivity> mapPools;
 
   public DatastoreCacheImpl(Datastore datastore) {
     this.usernames =
@@ -35,6 +37,8 @@ public class DatastoreCacheImpl implements Datastore {
                     // .refreshAfterWrite(15, TimeUnit.MINUTES)
                     .expireAfterAccess(1, TimeUnit.HOURS),
             datastore::getSettings);
+
+    this.mapPools = buildCache(builder -> builder.weakValues(), datastore::getPoolActivity);
   }
 
   // FIXME: Potential deadlock as a result of async loading, removed temporarily
@@ -64,5 +68,10 @@ public class DatastoreCacheImpl implements Datastore {
   @Override
   public Settings getSettings(UUID id) {
     return settings.getUnchecked(id);
+  }
+
+  @Override
+  public PoolActivity getPoolActivity(String poolName) {
+    return mapPools.getUnchecked(poolName);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/db/DatastoreCacheImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/DatastoreCacheImpl.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.bukkit.Bukkit;
 import tc.oc.pgm.api.Datastore;
-import tc.oc.pgm.api.map.PoolActivity;
+import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
 
@@ -16,7 +16,7 @@ public class DatastoreCacheImpl implements Datastore {
 
   private final LoadingCache<UUID, Username> usernames;
   private final LoadingCache<UUID, Settings> settings;
-  private final LoadingCache<String, PoolActivity> mapPools;
+  private final LoadingCache<String, MapActivity> mapPools;
 
   public DatastoreCacheImpl(Datastore datastore) {
     this.usernames =
@@ -38,7 +38,7 @@ public class DatastoreCacheImpl implements Datastore {
                     .expireAfterAccess(1, TimeUnit.HOURS),
             datastore::getSettings);
 
-    this.mapPools = buildCache(builder -> builder.weakValues(), datastore::getPoolActivity);
+    this.mapPools = buildCache(builder -> builder.weakValues(), datastore::getMapActivity);
   }
 
   // FIXME: Potential deadlock as a result of async loading, removed temporarily
@@ -71,7 +71,7 @@ public class DatastoreCacheImpl implements Datastore {
   }
 
   @Override
-  public PoolActivity getPoolActivity(String poolName) {
+  public MapActivity getMapActivity(String poolName) {
     return mapPools.getUnchecked(poolName);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/db/DatastoreImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/DatastoreImpl.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.PoolActivity;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
@@ -46,6 +47,7 @@ public class DatastoreImpl implements Datastore {
 
     initUsername();
     initSettings();
+    initPoolActivity();
   }
 
   @Override
@@ -252,6 +254,104 @@ public class DatastoreImpl implements Datastore {
       }
 
       statement.executeBatch();
+    }
+  }
+
+  @Override
+  public PoolActivity getPoolActivity(String name) {
+    PoolActivity activity = null;
+
+    try {
+      activity = selectMapPool(name);
+    } catch (SQLException e) {
+      logger.log(
+          Level.WARNING,
+          "Could not find pool activity for " + name + ". Creating default data now",
+          e);
+    }
+
+    if (activity == null) {
+      activity = new PoolActivityImpl(name, null, false);
+    }
+
+    return activity;
+  }
+
+  private class PoolActivityImpl implements PoolActivity {
+
+    private String name;
+    private String nextMap;
+    private boolean active;
+
+    public PoolActivityImpl(String name, @Nullable String nextMap, boolean active) {
+      this.name = name;
+      this.nextMap = nextMap;
+      this.active = active;
+    }
+
+    @Override
+    public String getPoolName() {
+      return name;
+    }
+
+    @Override
+    public String getNextMap() {
+      return nextMap;
+    }
+
+    @Override
+    public boolean isLastActive() {
+      return active;
+    }
+
+    @Override
+    public void updatePool(String nextMap, boolean active) {
+      this.nextMap = nextMap;
+      this.active = active;
+
+      try {
+        updateMapPool(name, getNextMap(), isLastActive());
+      } catch (SQLException e) {
+        logger.log(Level.WARNING, "Unable to update pool activity for " + name, e);
+      }
+    }
+  }
+
+  private void initPoolActivity() throws SQLException {
+    try (final Statement statement = getConnection().createStatement()) {
+      statement.addBatch(
+          "CREATE TABLE IF NOT EXISTS pools (name VARCHAR(255) PRIMARY KEY, next_map VARCHAR(255), last_active BOOLEAN)");
+      statement.executeBatch();
+    }
+  }
+
+  private PoolActivity selectMapPool(String name) throws SQLException {
+    PoolActivity activity = null;
+
+    try (final PreparedStatement statement =
+        getConnection().prepareStatement("SELECT * FROM pools WHERE name = ? LIMIT 1")) {
+      statement.setString(1, checkNotNull(name));
+
+      try (final ResultSet result = statement.executeQuery()) {
+        if (result.next()) {
+          final String next_map = result.getString(2);
+          final boolean active = result.getBoolean(3);
+
+          return new PoolActivityImpl(name, next_map, active);
+        }
+      }
+    }
+    return activity;
+  }
+
+  private void updateMapPool(String name, @Nullable String nextMap, boolean active)
+      throws SQLException {
+    try (final PreparedStatement statement =
+        getConnection().prepareStatement("INSERT OR REPLACE INTO pools VALUES (?, ?, ?)")) {
+      statement.setString(1, name);
+      statement.setString(2, nextMap);
+      statement.setBoolean(3, active);
+      statement.executeUpdate();
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -15,9 +15,9 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
-import tc.oc.pgm.api.map.PoolActivity;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.util.bukkit.translations.AllTranslations;
 
@@ -55,7 +55,7 @@ public class MapPoolManager implements MapOrder {
   }
 
   public @Nullable String getNextMapForPool(String poolName) {
-    return database.getPoolActivity(poolName).getNextMap();
+    return database.getMapActivity(poolName).getMapName();
   }
 
   private void loadMapPools() {
@@ -68,8 +68,8 @@ public class MapPoolManager implements MapOrder {
     mapPools.stream()
         .forEach(
             pool -> {
-              PoolActivity pa = database.getPoolActivity(pool.getName());
-              if (pa.isLastActive()) {
+              MapActivity ma = database.getMapActivity(pool.getName());
+              if (ma.isActive()) {
                 activeMapPool = pool;
                 logger.log(Level.INFO, "Resuming last active map pool (" + pool.getName() + ")");
               }
@@ -94,7 +94,7 @@ public class MapPoolManager implements MapOrder {
                 nextMap = pool.getNextMap().getName();
               }
               boolean active = activeMapPool.getName().equalsIgnoreCase(pool.getName());
-              database.getPoolActivity(pool.getName()).updatePool(nextMap, active);
+              database.getMapActivity(pool.getName()).update(nextMap, active);
             });
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
@@ -13,7 +13,7 @@ public class Rotation extends MapPool {
   public Rotation(MapPoolManager manager, ConfigurationSection section, String name) {
     super(manager, section, name);
 
-    @Nullable MapInfo nextMap = PGM.get().getMapLibrary().getMap(section.getString("next_map"));
+    @Nullable MapInfo nextMap = PGM.get().getMapLibrary().getMap(manager.getNextMapForPool(name));
     if (nextMap != null) this.position = getMapPosition(nextMap);
     else {
       PGM.get()
@@ -70,7 +70,6 @@ public class Rotation extends MapPool {
 
   public void advance(int positions) {
     position = (position + positions) % maps.size();
-    configSection.set("next_map", getMapInPosition(position).getName());
     manager.saveMapPools();
   }
 

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -4,9 +4,7 @@
 # Each new rotation or voted pool should follow the same configuration structure, within this file
 #
 # NOTE: Map names are case-sensitive
-#
-# Record for the last active map pool on the server, so that it can be resumed upon shutdown/restart
-last_active: default
+
 
 pools:
   default:
@@ -14,11 +12,6 @@ pools:
     type: ordered
     enabled: true
     players: 1
-    # next_map helps the server resume rotations in the position they were before a server shutdown/restart
-    # and is only used for ordered map pools.
-    # The next map for default is the first map in it's map list.
-    # This only applies when the server creates the map-pools.yml file for the first time
-    next_map: Airship Battle
     maps:
       - Airship Battle
       - Harb


### PR DESCRIPTION
# Introduce map-activity to the Datastore

Updated: April 9th, 2020

This fix will resolve #382.

After advice given by @Electroid, I made this PR work by converting the changes to make use to the `Datastore`. This should work seamlessly with existing server setups, as I tested with a used `pgm.db` and a newly generated one and both operated as intended.

As always suggestions are welcome and just let me know if anything should be adjusted and I’ll get right on it. 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>