### PR TITLE
Redraw sidebar on match end

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -336,7 +336,9 @@ public class SidebarMatchModule implements MatchModule, Listener {
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
-  public void matchEnd(MatchFinishEvent event) { renderSidebarDebounce();}
+  public void matchEnd(MatchFinishEvent event) {
+    renderSidebarDebounce();
+  }
 
   private String renderGoal(Goal<?> goal, @Nullable Competitor competitor, Party viewingParty) {
     StringBuilder sb = new StringBuilder(" ");

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -32,6 +32,7 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.match.event.MatchVictoryChangeEvent;
 import tc.oc.pgm.api.match.factory.MatchModuleFactory;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
@@ -333,6 +334,9 @@ public class SidebarMatchModule implements MatchModule, Listener {
   public void resultChange(MatchVictoryChangeEvent event) {
     renderSidebarDebounce();
   }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void matchEnd(MatchFinishEvent event) { renderSidebarDebounce();}
 
   private String renderGoal(Goal<?> goal, @Nullable Competitor competitor, Party viewingParty) {
     StringBuilder sb = new StringBuilder(" ");


### PR DESCRIPTION
This fixes #392 where objective touches aren't made public to everyone if a match ends via time limit. The scoreboard wasn't getting redrawn on match end, which normally doesn't cause issues because goal based matches always run the redraw function when someone completes the final goal. 

Signed-off-by: Eric Zeiberg <ejzeiberg@gmail.com>