### PR TITLE
Introduce non-dynamic map pools

### DIFF
--- a/core/src/main/java/tc/oc/pgm/Config.java
+++ b/core/src/main/java/tc/oc/pgm/Config.java
@@ -86,6 +86,10 @@ public class Config {
     public static String getPath() {
       return getConfiguration().getString("map-pools.path");
     }
+
+    public static boolean areStaffRequired() {
+      return getConfiguration().getBoolean("map-pools.require-staff", true);
+    }
   }
 
   public static class AutoRestart {

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -5,6 +5,7 @@ import app.ashcon.intake.bukkit.graph.BasicBukkitCommandGraph;
 import app.ashcon.intake.fluent.DispatcherNode;
 import app.ashcon.intake.parametric.AbstractModule;
 import app.ashcon.intake.parametric.provider.EnumProvider;
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -191,7 +192,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
           new MapPoolManager(
               logger, new File(getDataFolder(), Config.MapPools.getPath()), datastore);
     } else {
-      mapOrder = new RandomMapOrder();
+      mapOrder = new RandomMapOrder(Lists.newArrayList(mapLibrary.getMaps()));
     }
 
     prefixRegistry = new PrefixRegistryImpl();

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.community.events.PlayerPunishmentEvent;
 import tc.oc.pgm.community.modules.FreezeMatchModule;
 import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.chat.Sound;
 import tc.oc.pgm.util.component.Component;
@@ -63,11 +64,6 @@ public class ModerationCommands implements Listener {
       new PersonalizedText(" \u26a0 ").color(ChatColor.YELLOW);
   private static final Component BROADCAST_DIV =
       new PersonalizedText(" \u00BB ").color(ChatColor.GRAY);
-  private static final Component CONSOLE_NAME =
-      new PersonalizedTranslatable("console")
-          .getPersonalizedText()
-          .color(ChatColor.DARK_AQUA)
-          .italic(true);
 
   private final ChatDispatcher chat;
   private final MatchManager manager;
@@ -332,7 +328,10 @@ public class ModerationCommands implements Listener {
     if (punish(PunishmentType.KICK, targetMatchPlayer, sender, reason, silent)) {
       target.kickPlayer(
           formatPunishmentScreen(
-              PunishmentType.KICK, formatStaffName(sender, match), reason, null));
+              PunishmentType.KICK,
+              UsernameFormatUtils.formatStaffName(sender, match),
+              reason,
+              null));
     }
   }
 
@@ -353,7 +352,7 @@ public class ModerationCommands implements Listener {
     boolean tempBan = banLength != null && !banLength.isZero();
 
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
-    Component senderName = formatStaffName(sender, match);
+    Component senderName = UsernameFormatUtils.formatStaffName(sender, match);
     if (punish(
         tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN,
         targetMatchPlayer,
@@ -363,7 +362,7 @@ public class ModerationCommands implements Listener {
         silent)) {
       banPlayer(
           target.getName(), reason, senderName, tempBan ? Instant.now().plus(banLength) : null);
-      cacheRecentBan(target, formatStaffName(sender, match));
+      cacheRecentBan(target, UsernameFormatUtils.formatStaffName(sender, match));
       target.kickPlayer(
           formatPunishmentScreen(
               tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN,
@@ -406,7 +405,7 @@ public class ModerationCommands implements Listener {
               reason,
               null,
               ComponentRenderers.toLegacyText(
-                  formatStaffName(sender, manager.getMatch(sender)), sender));
+                  UsernameFormatUtils.formatStaffName(sender, manager.getMatch(sender)), sender));
 
       int onlineBans = 0;
       // Check all online players to find those with same IP.
@@ -418,12 +417,15 @@ public class ModerationCommands implements Listener {
 
             // Ban username to prevent rejoining
             banPlayer(
-                player.getName(), reason, formatStaffName(sender, matchPlayer.getMatch()), null);
+                player.getName(),
+                reason,
+                UsernameFormatUtils.formatStaffName(sender, matchPlayer.getMatch()),
+                null);
 
             player.kickPlayer(
                 formatPunishmentScreen(
                     PunishmentType.BAN,
-                    formatStaffName(sender, manager.getMatch(sender)),
+                    UsernameFormatUtils.formatStaffName(sender, manager.getMatch(sender)),
                     reason,
                     null));
             onlineBans++;
@@ -471,7 +473,7 @@ public class ModerationCommands implements Listener {
       throws CommandException {
     boolean tempBan = duration != null && !duration.isZero();
     PunishmentType type = tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN;
-    Component punisher = formatStaffName(sender, manager.getMatch(sender));
+    Component punisher = UsernameFormatUtils.formatStaffName(sender, manager.getMatch(sender));
 
     banPlayer(target, reason, punisher, tempBan ? Instant.now().plus(duration) : null);
     broadcastPunishment(
@@ -800,17 +802,6 @@ public class ModerationCommands implements Listener {
   }
 
   /*
-   * Format Punisher Name
-   */
-  public static Component formatStaffName(CommandSender sender, Match match) {
-    if (sender != null && sender instanceof Player) {
-      MatchPlayer matchPlayer = match.getPlayer((Player) sender);
-      if (matchPlayer != null) return matchPlayer.getStyledName(NameStyle.FANCY);
-    }
-    return CONSOLE_NAME;
-  }
-
-  /*
    * Format Reason
    */
   public static Component formatPunishmentReason(String reason) {
@@ -934,7 +925,7 @@ public class ModerationCommands implements Listener {
     Component reasonMsg = ModerationCommands.formatPunishmentReason(reason);
     Component formattedMsg =
         new PersonalizedText(
-            ModerationCommands.formatStaffName(sender, match),
+            UsernameFormatUtils.formatStaffName(sender, match),
             BROADCAST_DIV,
             prefix,
             BROADCAST_DIV,

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -332,7 +332,7 @@ public class ModerationCommands implements Listener {
     if (punish(PunishmentType.KICK, targetMatchPlayer, sender, reason, silent)) {
       target.kickPlayer(
           formatPunishmentScreen(
-              PunishmentType.KICK, formatPunisherName(sender, match), reason, null));
+              PunishmentType.KICK, formatStaffName(sender, match), reason, null));
     }
   }
 
@@ -353,7 +353,7 @@ public class ModerationCommands implements Listener {
     boolean tempBan = banLength != null && !banLength.isZero();
 
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
-    Component senderName = formatPunisherName(sender, match);
+    Component senderName = formatStaffName(sender, match);
     if (punish(
         tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN,
         targetMatchPlayer,
@@ -363,7 +363,7 @@ public class ModerationCommands implements Listener {
         silent)) {
       banPlayer(
           target.getName(), reason, senderName, tempBan ? Instant.now().plus(banLength) : null);
-      cacheRecentBan(target, formatPunisherName(sender, match));
+      cacheRecentBan(target, formatStaffName(sender, match));
       target.kickPlayer(
           formatPunishmentScreen(
               tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN,
@@ -406,7 +406,7 @@ public class ModerationCommands implements Listener {
               reason,
               null,
               ComponentRenderers.toLegacyText(
-                  formatPunisherName(sender, manager.getMatch(sender)), sender));
+                  formatStaffName(sender, manager.getMatch(sender)), sender));
 
       int onlineBans = 0;
       // Check all online players to find those with same IP.
@@ -418,12 +418,12 @@ public class ModerationCommands implements Listener {
 
             // Ban username to prevent rejoining
             banPlayer(
-                player.getName(), reason, formatPunisherName(sender, matchPlayer.getMatch()), null);
+                player.getName(), reason, formatStaffName(sender, matchPlayer.getMatch()), null);
 
             player.kickPlayer(
                 formatPunishmentScreen(
                     PunishmentType.BAN,
-                    formatPunisherName(sender, manager.getMatch(sender)),
+                    formatStaffName(sender, manager.getMatch(sender)),
                     reason,
                     null));
             onlineBans++;
@@ -471,7 +471,7 @@ public class ModerationCommands implements Listener {
       throws CommandException {
     boolean tempBan = duration != null && !duration.isZero();
     PunishmentType type = tempBan ? PunishmentType.TEMP_BAN : PunishmentType.BAN;
-    Component punisher = formatPunisherName(sender, manager.getMatch(sender));
+    Component punisher = formatStaffName(sender, manager.getMatch(sender));
 
     banPlayer(target, reason, punisher, tempBan ? Instant.now().plus(duration) : null);
     broadcastPunishment(
@@ -802,7 +802,7 @@ public class ModerationCommands implements Listener {
   /*
    * Format Punisher Name
    */
-  public static Component formatPunisherName(CommandSender sender, Match match) {
+  public static Component formatStaffName(CommandSender sender, Match match) {
     if (sender != null && sender instanceof Player) {
       MatchPlayer matchPlayer = match.getPlayer((Player) sender);
       if (matchPlayer != null) return matchPlayer.getStyledName(NameStyle.FANCY);
@@ -934,7 +934,7 @@ public class ModerationCommands implements Listener {
     Component reasonMsg = ModerationCommands.formatPunishmentReason(reason);
     Component formattedMsg =
         new PersonalizedText(
-            ModerationCommands.formatPunisherName(sender, match),
+            ModerationCommands.formatStaffName(sender, match),
             BROADCAST_DIV,
             prefix,
             BROADCAST_DIV,

--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -47,10 +47,10 @@ import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.ObserverInteractEvent;
-import tc.oc.pgm.community.commands.ModerationCommands;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.spawns.events.ObserverKitApplyEvent;
+import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
 import tc.oc.pgm.util.chat.Sound;
 import tc.oc.pgm.util.component.Component;
@@ -309,7 +309,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
     public void setFrozen(@Nullable CommandSender freezer, MatchPlayer freezee, boolean frozen) {
       freezee.setFrozen(frozen);
 
-      Component senderName = ModerationCommands.formatStaffName(freezer, freezee.getMatch());
+      Component senderName = UsernameFormatUtils.formatStaffName(freezer, freezee.getMatch());
 
       if (frozen) {
         freeze(freezee, senderName);

--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -309,7 +309,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
     public void setFrozen(@Nullable CommandSender freezer, MatchPlayer freezee, boolean frozen) {
       freezee.setFrozen(frozen);
 
-      Component senderName = ModerationCommands.formatPunisherName(freezer, freezee.getMatch());
+      Component senderName = ModerationCommands.formatStaffName(freezer, freezee.getMatch());
 
       if (frozen) {
         freeze(freezee, senderName);

--- a/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
@@ -1,0 +1,63 @@
+package tc.oc.pgm.events;
+
+import javax.annotation.Nullable;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.rotation.MapPool;
+
+/** MapPoolAdjustEvent is called when the active {@link MapPool} is set to another * */
+public class MapPoolAdjustEvent extends Event {
+
+  private final MapPool oldPool;
+  private final MapPool newPool;
+  private final Match match;
+
+  private final boolean forced;
+  private final CommandSender sender;
+
+  public MapPoolAdjustEvent(
+      MapPool oldMapPool,
+      MapPool newMapPool,
+      Match match,
+      boolean forced,
+      @Nullable CommandSender sender) {
+    this.oldPool = oldMapPool;
+    this.newPool = newMapPool;
+    this.match = match;
+    this.forced = forced;
+    this.sender = sender;
+  }
+
+  public MapPool getOldPool() {
+    return oldPool;
+  }
+
+  public MapPool getNewPool() {
+    return newPool;
+  }
+
+  public Match getMatch() {
+    return match;
+  }
+
+  public boolean isForced() {
+    return forced;
+  }
+
+  public CommandSender getSender() {
+    return sender;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.events;
 
+import java.time.Duration;
 import javax.annotation.Nullable;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
@@ -15,19 +16,22 @@ public class MapPoolAdjustEvent extends Event {
   private final Match match;
 
   private final boolean forced;
-  private final CommandSender sender;
+  private final @Nullable CommandSender sender;
+  private final @Nullable Duration timeLimit;
 
   public MapPoolAdjustEvent(
       MapPool oldMapPool,
       MapPool newMapPool,
       Match match,
       boolean forced,
-      @Nullable CommandSender sender) {
+      @Nullable CommandSender sender,
+      @Nullable Duration timeLimit) {
     this.oldPool = oldMapPool;
     this.newPool = newMapPool;
     this.match = match;
     this.forced = forced;
     this.sender = sender;
+    this.timeLimit = timeLimit;
   }
 
   public MapPool getOldPool() {
@@ -48,6 +52,10 @@ public class MapPoolAdjustEvent extends Event {
 
   public CommandSender getSender() {
     return sender;
+  }
+
+  public Duration getTimeLimit() {
+    return timeLimit;
   }
 
   private static final HandlerList handlers = new HandlerList();

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -42,14 +42,15 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.commands.MatchCommands;
-import tc.oc.pgm.community.commands.ModerationCommands;
 import tc.oc.pgm.events.MapPoolAdjustEvent;
 import tc.oc.pgm.events.PlayerParticipationStopEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.gamerules.GameRule;
 import tc.oc.pgm.gamerules.GameRulesMatchModule;
 import tc.oc.pgm.modules.TimeLockModule;
+import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.component.Component;
+import tc.oc.pgm.util.component.PeriodFormats;
 import tc.oc.pgm.util.component.types.PersonalizedText;
 import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
 import tc.oc.pgm.util.translations.AllTranslations;
@@ -315,14 +316,21 @@ public class PGMListener implements Listener {
     if (event.isForced()) {
       Component poolName =
           new PersonalizedText(event.getNewPool().getName()).color(ChatColor.LIGHT_PURPLE);
-      Component staffName = ModerationCommands.formatStaffName(event.getSender(), event.getMatch());
-      Component rotationForce =
-          new PersonalizedTranslatable("pools.poolChange.force", poolName, staffName)
-              .getPersonalizedText()
-              .color(ChatColor.GRAY);
-      ChatDispatcher.broadcastAdminChatMessage(rotationForce, event.getMatch());
+      Component staffName =
+          UsernameFormatUtils.formatStaffName(event.getSender(), event.getMatch());
+      PersonalizedTranslatable forced =
+          new PersonalizedTranslatable("pools.poolChange.force", poolName, staffName);
+      if (event.getTimeLimit() != null) {
+        Component time =
+            PeriodFormats.briefNaturalApproximate(event.getTimeLimit()).color(ChatColor.GREEN);
+        forced =
+            new PersonalizedTranslatable("pools.poolChange.force.timed", poolName, time, staffName);
+      }
+      ChatDispatcher.broadcastAdminChatMessage(
+          forced.getPersonalizedText().color(ChatColor.GRAY), event.getMatch());
     }
 
+    // Broadcast map pool changes due to size
     if (event.getNewPool().isDynamic()) {
       event
           .getMatch()

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -33,7 +33,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
         return new Rotation(manager, section, key);
       case "voted":
         return new VotingPool(manager, section, key);
-      case "random":
+      case "shuffled":
         return new RandomMapPool(manager, section, key);
       default:
         PGM.get().getLogger().severe("Invalid map pool type for " + key + ": '" + type + "'");

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -23,6 +23,8 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
   protected final List<MapInfo> maps;
   protected final int players;
 
+  protected final boolean dynamic;
+
   public static MapPool of(MapPoolManager manager, FileConfiguration config, String key) {
     ConfigurationSection section = config.getConfigurationSection("pools." + key);
     String type = section.getString("type").toLowerCase();
@@ -31,6 +33,8 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
         return new Rotation(manager, section, key);
       case "voted":
         return new VotingPool(manager, section, key);
+      case "random":
+        return new RandomMapPool(manager, section, key);
       default:
         PGM.get().getLogger().severe("Invalid map pool type for " + key + ": '" + type + "'");
         return new DisabledMapPool(manager, section, key);
@@ -43,6 +47,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
     this.name = name;
     this.enabled = section.getBoolean("enabled");
     this.players = section.getInt("players");
+    this.dynamic = section.getBoolean("dynamic", true);
 
     MapLibrary library = PGM.get().getMapLibrary();
     List<MapInfo> mapList =
@@ -68,6 +73,10 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
 
   public boolean isEnabled() {
     return enabled;
+  }
+
+  public boolean isDynamic() {
+    return dynamic;
   }
 
   public List<MapInfo> getMaps() {

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -4,22 +4,25 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import tc.oc.pgm.Config;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.util.translations.AllTranslations;
+import tc.oc.pgm.blitz.BlitzMatchModule;
+import tc.oc.pgm.events.MapPoolAdjustEvent;
 
 /**
  * Manages all the existing {@link MapPool}s, as for maintaining their order, and updating the one
@@ -32,6 +35,7 @@ public class MapPoolManager implements MapOrder {
   private FileConfiguration mapPoolFileConfig;
   private List<MapPool> mapPools = new ArrayList<>();
   private MapPool activeMapPool;
+
   /** When a {@link MapInfo} is manually set next, it overrides the rotation order * */
   private MapInfo overriderMap;
 
@@ -69,18 +73,18 @@ public class MapPoolManager implements MapOrder {
         .forEach(
             pool -> {
               MapActivity ma = database.getMapActivity(pool.getName());
-              if (ma.isActive()) {
+              if (ma.isActive() && !pool.isDynamic()) {
                 activeMapPool = pool;
                 logger.log(Level.INFO, "Resuming last active map pool (" + pool.getName() + ")");
               }
             });
 
     if (activeMapPool == null) {
-      logger.log(Level.WARNING, "No active map pool was found, defaulting to first defined pool.");
-      if (mapPools.get(0) != null) {
-        activeMapPool = mapPools.get(0);
-      } else {
-        logger.log(Level.SEVERE, "Failed to find any defined map pool!");
+      logger.log(Level.WARNING, "No active map pool was found, defaulting to first dynamic pool.");
+      activeMapPool = mapPools.stream().filter(mp -> mp.isDynamic()).findFirst().orElse(null);
+
+      if (activeMapPool == null) {
+        logger.log(Level.SEVERE, "Failed to find any dynamic map pool!");
       }
     }
   }
@@ -93,7 +97,9 @@ public class MapPoolManager implements MapOrder {
               if (pool instanceof Rotation) {
                 nextMap = pool.getNextMap().getName();
               }
-              boolean active = activeMapPool.getName().equalsIgnoreCase(pool.getName());
+              boolean active =
+                  activeMapPool.getName().equalsIgnoreCase(pool.getName())
+                      && activeMapPool.isDynamic();
               database.getMapActivity(pool.getName()).update(nextMap, active);
             });
   }
@@ -107,26 +113,22 @@ public class MapPoolManager implements MapOrder {
   }
 
   private void updateActiveMapPool(MapPool mapPool, Match match) {
+    updateActiveMapPool(mapPool, match, false, null);
+  }
+
+  public void updateActiveMapPool(
+      MapPool mapPool, Match match, boolean force, @Nullable CommandSender sender) {
     saveMapPools();
 
     if (mapPool == activeMapPool) return;
 
     activeMapPool.unloadPool(match);
-    activeMapPool = mapPool;
 
-    match.sendMessage(
-        ChatColor.WHITE
-            + "["
-            + ChatColor.GOLD
-            + "Rotations"
-            + ChatColor.WHITE
-            + "] "
-            + ChatColor.GREEN
-            + AllTranslations.get()
-                .translate(
-                    "pools.poolChange",
-                    Bukkit.getConsoleSender(),
-                    (ChatColor.AQUA + mapPool.getName() + ChatColor.GREEN)));
+    // Call a MapPoolAdjustEvent so plugins can listen when map pool has changed
+    match.callEvent(new MapPoolAdjustEvent(activeMapPool, mapPool, match, force, sender));
+
+    // Set new active pool
+    activeMapPool = mapPool;
   }
 
   /**
@@ -170,15 +172,30 @@ public class MapPoolManager implements MapOrder {
     activeMapPool.setNextMap(map); // Notify pool a next map has been set
   }
 
+  public Optional<MapPool> getAppropriateDynamicPool(Match match) {
+    int obs =
+        match.getModule(BlitzMatchModule.class) != null
+            ? (int) (match.getObservers().size() * 0.85)
+            : (match.getObservers().size() / 2);
+    int activePlayers = match.getPlayers().size() - obs;
+    return mapPools.stream()
+        .filter(rot -> activePlayers >= rot.getPlayers())
+        .max(MapPool::compareTo);
+  }
+
   @Override
   public void matchEnded(Match match) {
-    int activePlayers = match.getPlayers().size() - (match.getObservers().size() / 2);
-
-    mapPools.stream()
-        .filter(rot -> activePlayers >= rot.getPlayers())
-        .max(MapPool::compareTo)
-        .ifPresent(pool -> updateActiveMapPool(pool, match));
-
+    if (activeMapPool.isDynamic() || shouldRevert(match)) {
+      getAppropriateDynamicPool(match).ifPresent(pool -> updateActiveMapPool(pool, match));
+    }
     activeMapPool.matchEnded(match);
+  }
+
+  private boolean shouldRevert(Match match) {
+    return Config.MapPools.areStaffRequired()
+        && !match.getPlayers().stream()
+            .filter(mp -> mp.getBukkit().hasPermission(Permissions.STAFF))
+            .findAny()
+            .isPresent();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Random;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.map.exception.MapMissingException;
@@ -20,16 +19,18 @@ public class RandomMapOrder implements MapOrder {
 
   private final Random random;
   private final Deque<WeakReference<MapInfo>> deque;
+  private List<MapInfo> origMaps;
 
-  public RandomMapOrder() {
+  public RandomMapOrder(List<MapInfo> maps) {
     this.random = new Random();
     this.deque = new ArrayDeque<>();
+    this.origMaps = maps;
   }
 
   private void refresh() {
     if (!deque.isEmpty()) return; // Only re-populate when deque is empty
 
-    final List<MapInfo> maps = Lists.newArrayList(PGM.get().getMapLibrary().getMaps());
+    final List<MapInfo> maps = Lists.newArrayList(origMaps);
     if (maps.isEmpty())
       throw new RuntimeException(
           new MapMissingException("map library", "No maps found to set next"));

--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
@@ -1,0 +1,30 @@
+package tc.oc.pgm.rotation;
+
+import org.bukkit.configuration.ConfigurationSection;
+import tc.oc.pgm.api.map.MapInfo;
+
+/* RandomMapPool - A map pool which utilizes an instance of {@link RandomMapOrder} */
+public class RandomMapPool extends MapPool {
+
+  private final RandomMapOrder order;
+
+  public RandomMapPool(MapPoolManager manager, ConfigurationSection section, String name) {
+    super(manager, section, name);
+    this.order = new RandomMapOrder(maps);
+  }
+
+  @Override
+  public MapInfo popNextMap() {
+    return order.popNextMap();
+  }
+
+  @Override
+  public MapInfo getNextMap() {
+    return order.getNextMap();
+  }
+
+  @Override
+  public void setNextMap(MapInfo map) {
+    order.setNextMap(map);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
+++ b/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.util;
+
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.component.Component;
+import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
+import tc.oc.pgm.util.named.NameStyle;
+
+/**
+ * UsernameFormatUtils - A utility class with methods related to username formatting. Mainly used
+ * for {@link ModerationCommands} but could be useful in other places.
+ */
+public class UsernameFormatUtils {
+
+  private static final Component CONSOLE_NAME =
+      new PersonalizedTranslatable("console")
+          .getPersonalizedText()
+          .color(ChatColor.DARK_AQUA)
+          .italic(true);
+
+  public static Component formatStaffName(CommandSender sender, Match match) {
+    if (sender != null && sender instanceof Player) {
+      MatchPlayer matchPlayer = match.getPlayer((Player) sender);
+      if (matchPlayer != null) return matchPlayer.getStyledName(NameStyle.FANCY);
+    }
+    return CONSOLE_NAME;
+  }
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -12,7 +12,8 @@ map:
 map-pools:
   enabled: true
   path: map-pools.yml
-
+  require-staff: true          # Requires at least one online staff (pgm.staff) to stay on non-dynamic pool, will revert to dynamic pool if none are found.
+  
 restart:
   enabled: true
   uptime: 3h

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -7,7 +7,7 @@
 
 pools:
   default:
-    # Allowed types: ordered (rotation), voted (voted map pool), random (randomly selected maps)
+    # Allowed types: ordered (rotation), voted (voted map pool), shuffled (randomly selected order)
     type: ordered
     enabled: true
     dynamic: true # If set to true, map pool will be considered when adjusting to best fit player size.

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -5,12 +5,12 @@
 #
 # NOTE: Map names are case-sensitive
 
-
 pools:
   default:
-    # Allowed types: ordered (rotation), voted (voted map pool)
+    # Allowed types: ordered (rotation), voted (voted map pool), random (randomly selected maps)
     type: ordered
     enabled: true
+    dynamic: true # If set to true, map pool will be considered when adjusting to best fit player size.
     players: 1
     maps:
       - Airship Battle

--- a/util/src/main/i18n/templates/strings.properties
+++ b/util/src/main/i18n/templates/strings.properties
@@ -553,6 +553,7 @@ command.map.mapInfo.pools = Pools
 
 
 command.pools.noPoolMatch = No map pools matched query.
+command.pools.noDynamic = No dynamic pool could be found.
 command.pools.noRotation = No rotation currently in use.
 command.pools.noMapPools = No loaded map pools.
 command.pools.mapPool.title = Map pool
@@ -576,6 +577,11 @@ pools.poolChange = Map pool has been set to {0} in order to better adjust to the
 # {0} = Name of map pool
 # {1} = Name of sender
 pools.poolChange.force = The map pool has been set to {0} by {1}
+
+# {0} = Name of map pool
+# {1} = Duration of map pool 
+# {2} = Name of sender
+pools.poolChange.force.timed = The map pool has been set to {0} for {1} by {2}
 
 map.genre.objectives = Objectives
 map.genre.deathmatch = Deathmatch

--- a/util/src/main/i18n/templates/strings.properties
+++ b/util/src/main/i18n/templates/strings.properties
@@ -262,6 +262,7 @@ command.admin.start.unknownState = Match could not be started at this time.
 command.admin.end.unknownError = Match could not be ended at this time.
 
 command.admin.setNext.restartQueued = You may not set the next map when a restart is queued. Use -f to override.
+command.admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
 
 command.admin.mapreload.disabledAutomatic = This command is disabled. Maps will reload automatically if changes are detected.
 
@@ -372,8 +373,9 @@ match.playableArea.leaveAreaWarning = You may not leave the playing field
 # {0} = Maximum build height in meters
 match.maxBuildHeightWarning = You have reached the maximum build height ({0} blocks)
 
-# {0} = map title
-command.admin.set.success = Next map set to {0}
+# {0} = sender name
+# {1} = map title
+command.admin.set.success = {0} has set the next map to {1}
 
 # {0} = map title and version
 command.admin.mapreload.success = {0} successfully marked for reloading.
@@ -560,6 +562,9 @@ command.pools.mapPoolList.title = Loaded Map Pools
 command.pools.skip.message = Skipped a total of {0} positions.
 command.pools.skip.noNegative = You may not skip negative positions!
 
+# {0} = name of map pool
+command.pools.set.matching = {0} is already the current map pool.
+
 command.pool.vote.book.title = Map Vote
 command.pool.vote.book.header = Click to select all maps you would like to play:
 command.pool.vote.noVote = There is no poll to vote in currently.
@@ -567,6 +572,10 @@ command.pool.vote.voted = You have voted for {0}.
 command.pool.vote.removedVote = You removed your vote for {0}.
 
 pools.poolChange = Map pool has been set to {0} in order to better adjust to the current player count.
+
+# {0} = Name of map pool
+# {1} = Name of sender
+pools.poolChange.force = The map pool has been set to {0} by {1}
 
 map.genre.objectives = Objectives
 map.genre.deathmatch = Deathmatch


### PR DESCRIPTION
# Map Pool Improvements 🗺️ 
Changes to map pools, including a command to set specific map pools and the introduction of non-dynamic pools. 

## Non-Dynamic Pools
Running events can be difficult atm due to map pools dynamically adjusting to accommodate player counts. The solution is to introduce non-dynamic pools. When a non-dynamic pool is set, PGM will not adapt to different player counts as long as a staff member is online (this can be disabled via config if desired) and the non-dynamic pool is set. If the match ends and no staff are online, it will revert to an appropriate dynamic pool or this can be done manually.

Changes to `map-pools.yml`:
The major change that has been made to the map-pool file is the addition of a `dynamic:` field. By default no changes are required for current servers, as all map-pools will be set as dynamic unless specified false. The following config would be used if for example an all-blitz map pool was desired:
```yml
pools:
  blitz:
    type: ordered
    enabled: true
    dynamic: false
    players: 1
    maps: ...
```
When dynamic is set to false. This pool will never be set automatically by player counts, so `players:` is irrelevant. 

If a staff member wants this pool to be set, they would simply execute `/setpool blitz` 

Also added is a new event, `MapPoolAdjustEvent` which is called whenever the map pool is switched (both dynamically and non, including a isForced to determine if it was set by command). I'm hoping this will allow other plugins to listen for the event in order to add cool features, for example broadcasting a special message when a specific map pool is loaded.

## Other Changes
- Add a `random` option to map pools 
  - When `type: random` is set in the map-pools.yml, it will follow a rotation style but at complete random.
- Add a staff broadcast to `/setnext` 
- Adjust `/pools` format to include # of maps (non-dynamic pools do not show player counts)
- Fix so blitz maps don't bug dynamic pools (instead of counting obs at `0.5`, upped to `0.85` for blitz. Thanks @Pablete1234 )
- Renamed a method from ModerationCommands to better fit its purpose. 


## Screenshots
Additional information shown under `/pools` includes the map count per pool. Also non-dynamic pools can be identified by not having a players field.
![Screen Shot 2020-04-21 at 10 41 19 PM](https://user-images.githubusercontent.com/3377659/79945730-526fc580-8423-11ea-9364-a589632f39ee.png)

When `/setpool <pool>` is used, a useful message will be broadcast to inform staff.
![Screen Shot 2020-04-21 at 10 44 16 PM](https://user-images.githubusercontent.com/3377659/79945739-58fe3d00-8423-11ea-8439-92965d3f704b.png)

Similar to the previous screenshot, now staff will be alerted when a map is `/setnext`
![Screen Shot 2020-04-21 at 10 41 54 PM](https://user-images.githubusercontent.com/3377659/79945745-5b609700-8423-11ea-8e7f-99b364bcc36b.png)

## Feedback
After performing testing for a few days, I've yet to find any major problems so everything should be good :thumbsup:

As always I am open to feedback of any kind and will make changes where needed.

Only design question I had:
1. Was it a good idea to add the `map-pools.require-staff` to config, or was that unnecessary? 

Signed-off-by: applenick <applenick@users.noreply.github.com>