### PR TITLE
Fix out of bounds if next map not in rotation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
@@ -43,6 +43,11 @@ public class Rotation extends MapPool {
       }
     }
 
+    PGM.get()
+        .getLogger()
+        .log(
+            Level.SEVERE,
+            "Could not resolve next map from rotations. Resuming on initial position: 0");
     return 0;
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
@@ -37,16 +37,13 @@ public class Rotation extends MapPool {
   }
 
   private int getMapPosition(MapInfo map) {
-    int count = 0;
-
     for (int i = 0; i < maps.size(); i++) {
       if (maps.get(i).getName().equals(map.getName())) {
-        count = i;
-        break;
+        return i;
       }
     }
 
-    return count;
+    return 0;
   }
 
   private MapInfo getMapInPosition(int position) {

--- a/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/Rotation.java
@@ -39,9 +39,11 @@ public class Rotation extends MapPool {
   private int getMapPosition(MapInfo map) {
     int count = 0;
 
-    for (MapInfo pgmMap : maps) {
-      if (pgmMap.getName().equals(map.getName())) break;
-      count++;
+    for (int i = 0; i < maps.size(); i++) {
+      if (maps.get(i).getName().equals(map.getName())) {
+        count = i;
+        break;
+      }
     }
 
     return count;


### PR DESCRIPTION
If the next map as recorded in the database does not exist in the rotation, presently an IndexOutOfBoundsException will occur at load or when the first player attempts to join. This is because the current loop will increment `count` to the size of `maps` when it exhausts all possibilities.

This can occur, for example, if you modify the rotation, and the existing next map is removed from the new rotation.

Instead, we fix the loop to only iterate over the size of `maps`, and only when we find the matching map do we set the value of `count`. If no matching map is found, `count` remains 0 and returns to the start of the rotation.

Ideally, the database would probably store the current index, rather than the name, but this fixes this issue in the interim.

For reference, an example exception which occurred on Stratus in `AsyncPlayerPreLoginEvent` when a player attempted to join after we edited the rotations:

```
Caused by: java.lang.IndexOutOfBoundsException: Index: 38, Size: 38
        at java.util.ArrayList.rangeCheck(ArrayList.java:657) ~[?:1.8.0_252]
        at java.util.ArrayList.get(ArrayList.java:433) ~[?:1.8.0_252]
        at java.util.Collections$UnmodifiableList.get(Collections.java:1311) ~[?:1.8.0_252]
        at tc.oc.pgm.rotation.Rotation.getNextMap(Rotation.java:85) ~[?:?]
        at tc.oc.pgm.rotation.MapPoolManager.lambda$saveMapPools$2(MapPoolManager.java:94) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_252]
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647) ~[?:1.8.0_252]
        at tc.oc.pgm.rotation.MapPoolManager.saveMapPools(MapPoolManager.java:90) ~[?:?]
        at tc.oc.pgm.rotation.Rotation.advance(Rotation.java:73) ~[?:?]
        at tc.oc.pgm.rotation.Rotation.advance(Rotation.java:68) ~[?:?]
        at tc.oc.pgm.rotation.Rotation.popNextMap(Rotation.java:79) ~[?:?]
        at tc.oc.pgm.rotation.MapPoolManager.popNextMap(MapPoolManager.java:157) ~[?:?]
        at tc.oc.pgm.match.MatchManagerImpl.createMatch(MatchManagerImpl.java:104) ~[?:?]
        at tc.oc.pgm.listeners.PGMListener.onPrePlayerLogin(PGMListener.java:81) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_252]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_252]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_252]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_252]
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300) ~[sportpaper-1.8.8-R0.1-SNAPSHOT.jar:git-SportPaper-"374af6d3"]
        ... 10 more
[08:46:07 INFO]: UUID of player slayersource is 76b4cc36-f899-4c42-8ad5-f9ba48ffd4c4
[08:46:07 INFO]: slayersource lost connection: §cUh oh! We had an error. Please try rejoining.
```

Signed-off-by: Ian <46601096+iangbb@users.noreply.github.com>