### PR TITLE
Multiple fixes for various moderation features

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -528,15 +528,15 @@ public final class PGMConfig implements Config {
     }
 
     public static String getRulesLink() {
-      return BukkitUtils.colorize(PGM.get().getConfig().getString("moderation.rules-link", ""));
+      return BukkitUtils.colorize(PGM.get().getConfig().getString("community.rules-link", ""));
     }
 
     public static String getServerName() {
-      return BukkitUtils.colorize(PGM.get().getConfig().getString("moderation.server-name", ""));
+      return BukkitUtils.colorize(PGM.get().getConfig().getString("community.server-name", ""));
     }
 
     public static String getAppealMessage() {
-      return BukkitUtils.colorize(PGM.get().getConfig().getString("moderation.appeal-msg", ""));
+      return BukkitUtils.colorize(PGM.get().getConfig().getString("community.appeal-msg", ""));
     }
 
     public static boolean isAppealVisible() {

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -454,7 +454,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       node.registerCommands(vanishManager);
       registerEvents((Listener) vanishManager);
 
-      node.registerCommands(new ReportCommands());
+      node.registerCommands(new ReportCommands(datastore));
       node.registerCommands(new ListCommands(vanishManager));
     }
 

--- a/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
@@ -31,6 +31,9 @@ public interface MapOrder {
    */
   void setNextMap(MapInfo map);
 
+  /** Removes any map that was set manually, returning the server to what was previously chosen. */
+  void resetNextMap();
+
   /**
    * Notify the {@link MapOrder} that a match just ended, to allow it to run actions before cycle
    * starts.

--- a/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -146,7 +146,7 @@ public class AdminCommands {
                 .args(UsernameFormatUtils.formatStaffName(sender, match), mapName),
             match);
       } else {
-        viewer.sendWarning(TranslatableComponent.of("map.setNext.none"));
+        viewer.sendWarning(TranslatableComponent.of("map.noNextMap"));
       }
       return;
     }

--- a/core/src/main/java/tc/oc/pgm/commands/MatchCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MatchCommands.java
@@ -104,7 +104,10 @@ public class MatchCommands {
             + ChatColor.GRAY
             + ": "
             + ChatColor.WHITE
-            + match.getObservers().size());
+            + match.getObservers().stream()
+                .filter(mp -> !mp.isVanished())
+                .collect(Collectors.toList())
+                .size());
 
     sender.sendMessage(Joiner.on(ChatColor.DARK_GRAY + " | ").join(teamCountParts));
 

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -14,13 +14,17 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.event.HoverEvent;
+import net.kyori.text.event.HoverEvent.Action;
+import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -47,24 +51,20 @@ import tc.oc.pgm.util.PrettyPaginatedComponentResults;
 import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.chat.Sound;
-import tc.oc.pgm.util.component.Component;
 import tc.oc.pgm.util.component.ComponentRenderers;
 import tc.oc.pgm.util.component.ComponentUtils;
-import tc.oc.pgm.util.component.Components;
 import tc.oc.pgm.util.component.PeriodFormats;
 import tc.oc.pgm.util.component.types.PersonalizedText;
-import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.text.TextTranslations;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ModerationCommands implements Listener {
 
   private static final Sound WARN_SOUND = new Sound("mob.enderdragon.growl", 1f, 1f);
 
-  private static final Component WARN_SYMBOL =
-      new PersonalizedText(" \u26a0 ").color(ChatColor.YELLOW);
-  private static final Component BROADCAST_DIV =
-      new PersonalizedText(" \u00BB ").color(ChatColor.GRAY);
+  private static final Component WARN_SYMBOL = TextComponent.of(" \u26a0 ", TextColor.YELLOW);
+  private static final Component BROADCAST_DIV = TextComponent.of(" \u00BB ", TextColor.GRAY);
 
   private final ChatDispatcher chat;
   private final MatchManager manager;
@@ -98,60 +98,54 @@ public class ModerationCommands implements Listener {
   @Command(
       aliases = {"staff", "mods", "admins"},
       desc = "List the online staff members")
-  public void staff(CommandSender sender, Match match) {
+  public void staff(Audience viewer, CommandSender sender, Match match) {
     // List of online staff based off of permission
     List<Component> onlineStaff =
         match.getPlayers().stream()
-            .filter(player -> player.getBukkit().hasPermission(Permissions.STAFF))
-            .map(player -> player.getStyledName(NameStyle.FANCY))
+            .filter(
+                player ->
+                    (player.getBukkit().hasPermission(Permissions.STAFF)
+                        && (!player.isVanished() || sender.hasPermission(Permissions.STAFF))))
+            .map(p -> p.getName(NameStyle.VERBOSE))
             .collect(Collectors.toList());
 
     // FORMAT: Online Staff ({count}): {names}
     Component staffCount =
-        new PersonalizedText(Integer.toString(onlineStaff.size()))
-            .color(onlineStaff.isEmpty() ? ChatColor.RED : ChatColor.AQUA);
+        TextComponent.of(Integer.toString(onlineStaff.size()))
+            .color(onlineStaff.isEmpty() ? TextColor.RED : TextColor.AQUA);
 
     Component content =
         onlineStaff.isEmpty()
-            ? new PersonalizedTranslatable("moderation.staff.empty")
-                .getPersonalizedText()
-                .color(ChatColor.RED)
-            : new Component(
-                Components.join(new PersonalizedText(", ").color(ChatColor.GRAY), onlineStaff));
+            ? TranslatableComponent.of("moderation.staff.empty")
+            : TextComponent.join(TextComponent.of(", ", TextColor.GRAY), onlineStaff);
 
     Component staff =
-        new PersonalizedTranslatable("moderation.staff.name", staffCount, content)
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
+        TranslatableComponent.of("moderation.staff.name", TextColor.GRAY).args(staffCount, content);
 
     // Send message
-    sender.sendMessage(staff);
+    viewer.sendMessage(staff);
   }
 
   @Command(
       aliases = {"frozenlist", "fls", "flist"},
       desc = "View a list of frozen players",
       perms = Permissions.FREEZE)
-  public void sendFrozenList(CommandSender sender, Match match) {
+  public void sendFrozenList(Audience sender, Match match) {
     FreezeMatchModule fmm = match.getModule(FreezeMatchModule.class);
 
     if (fmm.getFrozenPlayers().isEmpty() && fmm.getOfflineFrozenCount() < 1) {
-      sender.sendMessage(
-          new PersonalizedTranslatable("moderation.freeze.frozenList.none")
-              .getPersonalizedText()
-              .color(ChatColor.RED));
+      sender.sendWarning(TranslatableComponent.of("moderation.freeze.frozenList.none"));
       return;
     }
 
     // Online Players
     if (!fmm.getFrozenPlayers().isEmpty()) {
       Component names =
-          new Component(
-              Components.join(
-                  new PersonalizedText(", ").color(ChatColor.GRAY),
-                  fmm.getFrozenPlayers().stream()
-                      .map(m -> m.getStyledName(NameStyle.FANCY))
-                      .collect(Collectors.toList())));
+          TextComponent.join(
+              TextComponent.of(", ", TextColor.GRAY),
+              fmm.getFrozenPlayers().stream()
+                  .map(m -> m.getName(NameStyle.FANCY))
+                  .collect(Collectors.toList()));
       sender.sendMessage(
           formatFrozenList(
               "moderation.freeze.frozenList.online", fmm.getFrozenPlayers().size(), names));
@@ -159,7 +153,7 @@ public class ModerationCommands implements Listener {
 
     // Offline Players
     if (fmm.getOfflineFrozenCount() > 0) {
-      Component names = new PersonalizedText(fmm.getOfflineFrozenNames());
+      Component names = TextComponent.of(fmm.getOfflineFrozenNames());
       sender.sendMessage(
           formatFrozenList(
               "moderation.freeze.frozenList.offline", fmm.getOfflineFrozenCount(), names));
@@ -167,55 +161,53 @@ public class ModerationCommands implements Listener {
   }
 
   private Component formatFrozenList(String key, int count, Component names) {
-    return new PersonalizedTranslatable(
-            key, new PersonalizedText(Integer.toString(count), ChatColor.AQUA), names)
-        .getPersonalizedText()
-        .color(ChatColor.GRAY);
+    return TranslatableComponent.of(key, TextColor.GRAY)
+        .args(TextComponent.of(Integer.toString(count), TextColor.AQUA), names);
   }
 
   @Command(
       aliases = {"freeze", "fz", "f"},
       usage = "<player>",
+      flags = "s",
       desc = "Freeze a player",
       perms = Permissions.FREEZE)
-  public void freeze(CommandSender sender, Match match, Player target) throws CommandException {
-    setFreeze(sender, match, target, true);
+  public void freeze(CommandSender sender, Match match, Player target, @Switch('s') boolean silent)
+      throws CommandException {
+    setFreeze(sender, match, target, true, silent);
   }
 
   @Command(
       aliases = {"unfreeze", "uf"},
       usage = "<player>",
+      flags = "s",
       desc = "Unfreeze a player",
       perms = Permissions.FREEZE)
-  public void unFreeze(CommandSender sender, Match match, Player target) throws CommandException {
-    setFreeze(sender, match, target, false);
+  public void unFreeze(
+      CommandSender sender, Match match, Player target, @Switch('s') boolean silent)
+      throws CommandException {
+    setFreeze(sender, match, target, false, silent);
   }
 
-  private void setFreeze(CommandSender sender, Match match, Player target, boolean freeze)
+  private void setFreeze(
+      CommandSender sender, Match match, Player target, boolean freeze, boolean silent)
       throws CommandException {
     FreezeMatchModule fmm = match.getModule(FreezeMatchModule.class);
     MatchPlayer player = match.getPlayer(target);
 
     Component alreadyFrozen =
-        new PersonalizedTranslatable(
-                "moderation.freeze.alreadyFrozen",
-                match.getPlayer(target).getStyledName(NameStyle.FANCY))
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
+        TranslatableComponent.of("moderation.freeze.alreadyFrozen", TextColor.GRAY)
+            .args(match.getPlayer(target).getName(NameStyle.FANCY));
     Component alreadyThawed =
-        new PersonalizedTranslatable(
-                "moderation.freeze.alreadyThawed",
-                match.getPlayer(target).getStyledName(NameStyle.FANCY))
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
+        TranslatableComponent.of("moderation.freeze.alreadyThawed", TextColor.GRAY)
+            .args(match.getPlayer(target).getName(NameStyle.FANCY));
 
     if (player != null) {
       if (fmm.isFrozen(player) && freeze) {
-        throw new CommandException(ComponentRenderers.toLegacyText(alreadyFrozen, sender));
+        throw new CommandException(TextTranslations.translateLegacy(alreadyFrozen, sender));
       } else if (!fmm.isFrozen(player) && !freeze) {
-        throw new CommandException(ComponentRenderers.toLegacyText(alreadyThawed, sender));
+        throw new CommandException(TextTranslations.translateLegacy(alreadyThawed, sender));
       } else {
-        fmm.setFrozen(sender, player, freeze);
+        fmm.setFrozen(sender, player, freeze, silent);
       }
     }
   }
@@ -225,14 +217,13 @@ public class ModerationCommands implements Listener {
       usage = "<player> <reason>",
       desc = "Mute a player",
       perms = Permissions.MUTE)
-  public void mute(CommandSender sender, Player target, Match match, @Text String reason) {
+  public void mute(
+      Audience viewer, CommandSender sender, Player target, Match match, @Text String reason) {
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
     if (chat.isMuted(targetMatchPlayer)) {
-      sender.sendMessage(
-          new PersonalizedTranslatable(
-                  "moderation.mute.existing", targetMatchPlayer.getStyledName(NameStyle.FANCY))
-              .getPersonalizedText()
-              .color(ChatColor.RED));
+      viewer.sendWarning(
+          TranslatableComponent.of("moderation.mute.existing")
+              .args(targetMatchPlayer.getName(NameStyle.FANCY)));
       return;
     }
 
@@ -248,33 +239,31 @@ public class ModerationCommands implements Listener {
       aliases = {"mutes", "mutelist"},
       desc = "List of muted players",
       perms = Permissions.MUTE)
-  public void listMutes(CommandSender sender, MatchManager manager) throws CommandException {
-    Set<UUID> mutes = chat.getMutedUUIDs();
+  public void listMutes(Audience viewer, CommandSender sender, MatchManager manager)
+      throws CommandException {
     List<Component> onlineMutes =
-        mutes.stream()
+        chat.getMutedUUIDs().stream()
             .filter(u -> (manager.getPlayer(u) != null))
             .map(manager::getPlayer)
-            .map(p -> p.getStyledName(NameStyle.CONCISE))
+            .map(mp -> mp.getName(NameStyle.FANCY))
             .collect(Collectors.toList());
     if (onlineMutes.isEmpty()) {
       throw new CommandException(
-          ComponentRenderers.toLegacyText(
-              new PersonalizedTranslatable("moderation.mute.none"), sender));
+          TextTranslations.translateLegacy(
+              TranslatableComponent.of("moderation.mute.none", TextColor.RED), sender));
     }
 
-    Component names =
-        new Component(
-            Components.join(new PersonalizedText(", ").color(ChatColor.GRAY), onlineMutes));
+    Component names = TextComponent.join(TextComponent.of(", ", TextColor.GRAY), onlineMutes);
     Component message =
-        new PersonalizedText(
-            new PersonalizedTranslatable("moderation.mute.list")
-                .getPersonalizedText()
-                .color(ChatColor.GOLD),
-            new PersonalizedText(" (").color(ChatColor.GRAY),
-            new PersonalizedText(Integer.toString(onlineMutes.size())).color(ChatColor.YELLOW),
-            new PersonalizedText("): ").color(ChatColor.GRAY),
-            names);
-    sender.sendMessage(message);
+        TextComponent.builder()
+            .append(TranslatableComponent.of("moderation.mute.list", TextColor.GOLD))
+            .append("(", TextColor.GRAY)
+            .append(Integer.toString(onlineMutes.size()), TextColor.YELLOW)
+            .append("): ", TextColor.GRAY)
+            .append(names)
+            .build();
+
+    viewer.sendMessage(message);
   }
 
   @Command(
@@ -282,26 +271,19 @@ public class ModerationCommands implements Listener {
       usage = "<player>",
       desc = "Unmute a player",
       perms = Permissions.MUTE)
-  public void unMute(CommandSender sender, Player target, Match match) {
+  public void unMute(Audience viewer, CommandSender sender, Player target, Match match) {
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
     if (chat.isMuted(targetMatchPlayer)) {
       chat.removeMuted(targetMatchPlayer);
-
       targetMatchPlayer.sendMessage(
-          new PersonalizedTranslatable("moderation.unmute.target")
-              .getPersonalizedText()
-              .color(ChatColor.GREEN));
-
-      sender.sendMessage(
-          new PersonalizedTranslatable(
-                  "moderation.unmute.sender", targetMatchPlayer.getStyledName(NameStyle.FANCY))
-              .color(ChatColor.GRAY));
+          TranslatableComponent.of("moderation.unmute.target", TextColor.GREEN));
+      viewer.sendMessage(
+          TranslatableComponent.of("moderation.unmute.sender", TextColor.GRAY)
+              .args(targetMatchPlayer.getName(NameStyle.FANCY)));
     } else {
-      sender.sendMessage(
-          new PersonalizedTranslatable(
-                  "moderation.unmute.none", targetMatchPlayer.getStyledName(NameStyle.FANCY))
-              .getPersonalizedText()
-              .color(ChatColor.RED));
+      viewer.sendMessage(
+          TranslatableComponent.of("moderation.unmute.none", TextColor.RED)
+              .args(targetMatchPlayer.getName(NameStyle.FANCY)));
     }
   }
 
@@ -332,6 +314,13 @@ public class ModerationCommands implements Listener {
     silent = checkSilent(silent, sender);
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
     if (punish(PunishmentType.KICK, targetMatchPlayer, sender, reason, silent)) {
+
+      // Unfreeze players who are kicked
+      FreezeMatchModule fmm = match.getModule(FreezeMatchModule.class);
+      if (fmm.isFrozen(targetMatchPlayer)) {
+        fmm.setFrozen(sender, targetMatchPlayer, false, false);
+      }
+
       target.kickPlayer(
           formatPunishmentScreen(
               PunishmentType.KICK,
@@ -345,7 +334,7 @@ public class ModerationCommands implements Listener {
       aliases = {"ban", "permban", "pb"},
       usage = "<player> <reason> -s (silent) -t (time)",
       desc = "Ban an online player from the server",
-      flags = "s",
+      flags = "st",
       perms = Permissions.BAN)
   public void ban(
       CommandSender sender,
@@ -386,6 +375,7 @@ public class ModerationCommands implements Listener {
       flags = "s",
       perms = Permissions.BAN)
   public void ipBan(
+      Audience viewer,
       CommandSender sender,
       MatchManager manager,
       String target,
@@ -412,7 +402,7 @@ public class ModerationCommands implements Listener {
               address,
               reason,
               null,
-              ComponentRenderers.toLegacyText(
+              TextTranslations.translateLegacy(
                   UsernameFormatUtils.formatStaffName(sender, manager.getMatch(sender)), sender));
 
       int onlineBans = 0;
@@ -441,28 +431,26 @@ public class ModerationCommands implements Listener {
         }
       }
 
-      Component formattedTarget = new PersonalizedText(target).color(ChatColor.DARK_AQUA);
+      Component formattedTarget = TextComponent.of(target, TextColor.DARK_AQUA);
       if (onlineBans > 0) {
-        sender.sendMessage(
-            new PersonalizedTranslatable(
-                    "moderation.ipBan.bannedWithAlts",
+        viewer.sendWarning(
+            TranslatableComponent.of("moderation.ipBan.bannedWithAlts")
+                .args(
                     formattedTarget,
-                    new PersonalizedText(Integer.toString(onlineBans)).color(ChatColor.AQUA))
-                .getPersonalizedText()
-                .color(ChatColor.RED));
+                    TextComponent.of(
+                        Integer.toString(
+                            targetPlayer == null ? onlineBans : Math.max(0, onlineBans - 1)),
+                        TextColor.AQUA)));
       } else {
-        sender.sendMessage(
-            new PersonalizedTranslatable("moderation.ipBan.banned", formattedTarget)
-                .getPersonalizedText()
-                .color(ChatColor.RED));
+        viewer.sendMessage(
+            TranslatableComponent.of("moderation.ipBan.banned", TextColor.RED)
+                .args(formattedTarget));
       }
 
     } else {
-      sender.sendMessage(
-          new PersonalizedTranslatable(
-                  "moderation.ipBan.invalidIP",
-                  new PersonalizedText(address).color(ChatColor.RED).italic(true))
-              .color(ChatColor.GRAY));
+      viewer.sendMessage(
+          TranslatableComponent.of("moderation.ipBan.invalidIP", TextColor.GRAY)
+              .args(TextComponent.of(address, TextColor.RED, TextDecoration.ITALIC)));
     }
   }
 
@@ -488,7 +476,7 @@ public class ModerationCommands implements Listener {
         type,
         manager.getMatch(sender),
         sender,
-        new PersonalizedText(target).color(ChatColor.DARK_AQUA),
+        TextComponent.of(target, TextColor.DARK_AQUA),
         reason,
         true,
         duration);
@@ -507,7 +495,7 @@ public class ModerationCommands implements Listener {
       desc = "List online players on the same IP",
       perms = Permissions.STAFF)
   public void alts(
-      Audience audience,
+      Audience viewer,
       CommandSender sender,
       MatchManager manager,
       @Fallback(Type.NULL) Player targetPl,
@@ -517,13 +505,11 @@ public class ModerationCommands implements Listener {
       MatchPlayer target = manager.getPlayer(targetPl);
       List<MatchPlayer> alts = getAltAccounts(targetPl, manager);
       if (alts.isEmpty()) {
-        sender.sendMessage(
-            new PersonalizedTranslatable(
-                    "moderation.alts.noAlts", target.getStyledName(NameStyle.FANCY))
-                .getPersonalizedText()
-                .color(ChatColor.RED));
+        viewer.sendMessage(
+            TranslatableComponent.of("moderation.alts.noAlts", TextColor.RED)
+                .args(target.getName(NameStyle.FANCY)));
       } else {
-        sender.sendMessage(formatAltAccountList(target, alts));
+        viewer.sendMessage(formatAltAccountList(target, alts));
       }
     } else {
       List<Component> altAccounts = Lists.newArrayList();
@@ -546,30 +532,27 @@ public class ModerationCommands implements Listener {
       int pages = (altAccounts.size() + perPage - 1) / perPage;
 
       Component pageNum =
-          new PersonalizedTranslatable(
-                  "command.simplePageHeader",
-                  new PersonalizedText(Integer.toString(page)).color(ChatColor.DARK_AQUA),
-                  new PersonalizedText(Integer.toString(pages)).color(ChatColor.DARK_AQUA))
-              .getPersonalizedText()
-              .color(ChatColor.GRAY);
+          TranslatableComponent.of("command.simplePageHeader", TextColor.GRAY)
+              .args(
+                  TextComponent.of(Integer.toString(page), TextColor.DARK_AQUA),
+                  TextComponent.of(Integer.toString(pages), TextColor.DARK_AQUA));
 
       Component headerText =
-          new PersonalizedTranslatable("moderation.alts.header")
-              .getPersonalizedText()
-              .color(ChatColor.DARK_AQUA);
+          TranslatableComponent.of("moderation.alts.header", TextColor.DARK_AQUA);
 
       Component header =
-          new PersonalizedText(
-              headerText,
-              new PersonalizedText(" (").color(ChatColor.GRAY),
-              new PersonalizedText(Integer.toString(altAccounts.size())).color(ChatColor.DARK_AQUA),
-              new PersonalizedText(") » Page ").color(ChatColor.GRAY),
-              pageNum);
+          TextComponent.builder()
+              .append(headerText)
+              .append(" (", TextColor.GRAY)
+              .append(Integer.toString(altAccounts.size()), TextColor.DARK_AQUA)
+              .append(") » Page ", TextColor.GRAY)
+              .append(pageNum)
+              .build();
 
       Component formattedHeader =
-          new PersonalizedText(
+          TextComponent.of(
               ComponentUtils.horizontalLineHeading(
-                  ComponentRenderers.toLegacyText(header, sender), ChatColor.BLUE));
+                  TextTranslations.translateLegacy(header, sender), ChatColor.BLUE));
 
       new PrettyPaginatedComponentResults<Component>(formattedHeader, perPage) {
         @Override
@@ -579,9 +562,9 @@ public class ModerationCommands implements Listener {
 
         @Override
         public Component formatEmpty() throws CommandException {
-          throw new CommandException("No alternate accounts found!");
+          throw new CommandException(ChatColor.RED + "No alternate accounts found!");
         }
-      }.display(audience, altAccounts, page);
+      }.display(viewer, altAccounts, page);
     }
   }
 
@@ -590,7 +573,8 @@ public class ModerationCommands implements Listener {
       usage = "[player/uuid]",
       desc = "Lookup baninfo about a player",
       perms = Permissions.STAFF)
-  public void banInfo(CommandSender sender, String target) throws CommandException {
+  public void banInfo(Audience viewer, CommandSender sender, String target)
+      throws CommandException {
 
     if (!XMLUtils.USERNAME_REGEX.matcher(target).matches()) {
       UUID uuid = UUID.fromString(target);
@@ -599,12 +583,9 @@ public class ModerationCommands implements Listener {
         target = username.getName();
       } else {
         throw new CommandException(
-            ComponentRenderers.toLegacyText(
-                new PersonalizedTranslatable(
-                        "command.notJoinedServer",
-                        new PersonalizedText(target).color(ChatColor.AQUA))
-                    .getPersonalizedText()
-                    .color(ChatColor.RED),
+            TextTranslations.translateLegacy(
+                TranslatableComponent.of("command.notJoinedServer", TextColor.RED)
+                    .args(TextComponent.of(target, TextColor.AQUA)),
                 sender));
       }
     }
@@ -614,30 +595,21 @@ public class ModerationCommands implements Listener {
     if (ban == null
         || ban.getExpiration() != null && ban.getExpiration().toInstant().isBefore(Instant.now())) {
       throw new CommandException(
-          ComponentRenderers.toLegacyText(
-              new PersonalizedTranslatable(
-                  "moderation.records.lookupNone",
-                  new PersonalizedText(target).color(ChatColor.DARK_AQUA)),
+          TextTranslations.translateLegacy(
+              TranslatableComponent.of("moderation.records.lookupNone")
+                  .args(TextComponent.of(target, TextColor.DARK_AQUA)),
               sender));
     }
 
     Component header =
-        new PersonalizedText(
-            new PersonalizedTranslatable("moderation.records.header")
-                .getPersonalizedText()
-                .color(ChatColor.GRAY),
-            new PersonalizedText(" » ").color(ChatColor.GOLD),
-            new PersonalizedText(target).color(ChatColor.DARK_AQUA).italic(true));
-    new PersonalizedTranslatable(
-            "moderation.records.header", new PersonalizedText(target).color(ChatColor.DARK_AQUA))
-        .getPersonalizedText()
-        .color(ChatColor.DARK_GREEN);
+        TextComponent.builder()
+            .append(TranslatableComponent.of("moderation.records.header", TextColor.GRAY))
+            .append(BROADCAST_DIV)
+            .append(target, TextColor.DARK_AQUA, TextDecoration.ITALIC)
+            .build();
     boolean expires = ban.getExpiration() != null;
-    Component banType =
-        new PersonalizedTranslatable("moderation.type.ban")
-            .getPersonalizedText()
-            .color(ChatColor.GOLD);
-    Component expireDate = Components.blank();
+    Component banType = TranslatableComponent.of("moderation.type.ban", TextColor.GOLD);
+    Component expireDate = TextComponent.empty();
     if (expires) {
       String length =
           ComponentRenderers.toLegacyText(
@@ -655,20 +627,15 @@ public class ModerationCommands implements Listener {
               sender);
 
       banType =
-          new PersonalizedTranslatable(
-                  "moderation.type.temp_ban",
-                  new PersonalizedText(
+          TranslatableComponent.of("moderation.type.temp_ban", TextColor.GOLD)
+              .args(
+                  TextComponent.of(
                       length.lastIndexOf('s') != -1
                           ? length.substring(0, length.lastIndexOf('s'))
-                          : length))
-              .getPersonalizedText()
-              .color(ChatColor.GOLD);
+                          : length));
       expireDate =
-          new PersonalizedTranslatable(
-                  "moderation.screen.expires",
-                  new PersonalizedText(remaining).color(ChatColor.YELLOW))
-              .getPersonalizedText()
-              .color(ChatColor.GRAY);
+          TranslatableComponent.of("moderation.screen.expires", TextColor.GRAY)
+              .args(TextComponent.of(remaining, TextColor.YELLOW));
     }
 
     String createdAgo =
@@ -678,54 +645,47 @@ public class ModerationCommands implements Listener {
             sender);
 
     Component banTypeFormatted =
-        new PersonalizedTranslatable("moderation.type", banType)
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
+        TranslatableComponent.of("moderation.type", TextColor.GRAY).args(banType);
 
     Component reason =
-        new PersonalizedTranslatable(
-                "moderation.records.reason",
-                new PersonalizedText(ban.getReason()).color(ChatColor.RED))
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
+        TranslatableComponent.of("moderation.records.reason", TextColor.GRAY)
+            .args(TextComponent.of(ban.getReason(), TextColor.RED));
     Component source =
-        new PersonalizedText(
-            new PersonalizedTranslatable(
-                    "moderation.screen.signoff",
-                    new PersonalizedText(ban.getSource()).color(ChatColor.AQUA))
-                .getPersonalizedText()
-                .color(ChatColor.GRAY),
-            Components.space(),
-            new PersonalizedText(createdAgo).color(ChatColor.GRAY));
+        TextComponent.builder()
+            .append(
+                TranslatableComponent.of("moderation.screen.signoff", TextColor.GRAY)
+                    .args(TextComponent.of(ban.getSource(), TextColor.AQUA)))
+            .append(TextComponent.space())
+            .append(TextComponent.of(createdAgo, TextColor.GRAY))
+            .build();
 
-    sender.sendMessage(
+    viewer.sendMessage(
         ComponentUtils.horizontalLineHeading(
-            ComponentRenderers.toLegacyText(header, sender), ChatColor.DARK_PURPLE));
-    sender.sendMessage(banTypeFormatted);
-    sender.sendMessage(reason);
-    sender.sendMessage(source);
+            TextTranslations.translateLegacy(header, sender), ChatColor.DARK_PURPLE));
+    viewer.sendMessage(banTypeFormatted);
+    viewer.sendMessage(reason);
+    viewer.sendMessage(source);
     if (expires) {
-      sender.sendMessage(expireDate);
+      viewer.sendMessage(expireDate);
     }
   }
 
   private Component formatAltAccountList(MatchPlayer target, List<MatchPlayer> alts) {
-    BaseComponent names =
-        Components.join(
-            new PersonalizedText(", ").color(ChatColor.GRAY),
-            alts.stream()
-                .map(mp -> mp.getStyledName(NameStyle.CONCISE))
-                .collect(Collectors.toList()));
-    Component size = new PersonalizedText(Integer.toString(alts.size())).color(ChatColor.YELLOW);
+    Component names =
+        TextComponent.join(
+            TextComponent.of(", ", TextColor.GRAY),
+            alts.stream().map(mp -> mp.getName(NameStyle.CONCISE)).collect(Collectors.toList()));
+    Component size = TextComponent.of(Integer.toString(alts.size()), TextColor.YELLOW);
 
-    return new PersonalizedText(
-        new PersonalizedText("[").color(ChatColor.GOLD),
-        target.getStyledName(NameStyle.VERBOSE),
-        new PersonalizedText("] ").color(ChatColor.GOLD),
-        new PersonalizedText("(").color(ChatColor.GRAY),
-        size,
-        new PersonalizedText("): ").color(ChatColor.GRAY),
-        new Component(names));
+    return TextComponent.builder()
+        .append("[", TextColor.GOLD)
+        .append(target.getName(NameStyle.VERBOSE))
+        .append("] ", TextColor.GOLD)
+        .append("(", TextColor.GRAY)
+        .append(size)
+        .append("): ", TextColor.GRAY)
+        .append(names)
+        .build();
   }
 
   private List<MatchPlayer> getAltAccounts(Player target, MatchManager manager) {
@@ -790,22 +750,18 @@ public class ModerationCommands implements Listener {
     }
 
     public Component getPunishmentPrefix() {
-      return new PersonalizedTranslatable(PREFIX_TRANSLATE_KEY + name().toLowerCase())
-          .getPersonalizedText()
-          .color(ChatColor.GOLD);
+      return TranslatableComponent.of(PREFIX_TRANSLATE_KEY + name().toLowerCase(), TextColor.GOLD);
     }
 
     public Component getPunishmentPrefix(Component time) {
-      return new PersonalizedTranslatable(PREFIX_TRANSLATE_KEY + name().toLowerCase(), time)
-          .getPersonalizedText()
-          .color(ChatColor.GOLD);
+      return TranslatableComponent.of(PREFIX_TRANSLATE_KEY + name().toLowerCase(), TextColor.GOLD)
+          .args(time);
     }
 
     public Component getScreenComponent(Component reason) {
-      if (!screen) return Components.blank();
-      return new PersonalizedTranslatable(SCREEN_TRANSLATE_KEY + name().toLowerCase(), reason)
-          .getPersonalizedText()
-          .color(ChatColor.GOLD);
+      if (!screen) return TextComponent.empty();
+      return TranslatableComponent.of(SCREEN_TRANSLATE_KEY + name().toLowerCase(), TextColor.GOLD)
+          .args(reason);
     }
   }
 
@@ -813,7 +769,7 @@ public class ModerationCommands implements Listener {
    * Format Reason
    */
   public static Component formatPunishmentReason(String reason) {
-    return new PersonalizedText(reason).color(ChatColor.RED);
+    return TextComponent.of(reason, TextColor.RED);
   }
 
   /*
@@ -824,71 +780,74 @@ public class ModerationCommands implements Listener {
     List<Component> lines = Lists.newArrayList();
 
     Component header =
-        new PersonalizedText(
+        TextComponent.of(
             ComponentUtils.horizontalLineHeading(
                 PGMConfig.Moderation.getServerName(), ChatColor.DARK_GRAY));
-
     Component footer =
-        new PersonalizedText(
+        TextComponent.of(
             ComponentUtils.horizontalLine(ChatColor.DARK_GRAY, ComponentUtils.MAX_CHAT_WIDTH));
 
     lines.add(header); // Header Line (server name) - START
-    lines.add(Components.blank());
+    lines.add(TextComponent.empty());
     lines.add(type.getScreenComponent(formatPunishmentReason(reason))); // The reason
-    lines.add(Components.blank());
+    lines.add(TextComponent.empty());
 
     // If punishment expires, inform user when
     if (expires != null) {
       Component timeLeft =
-          PeriodFormats.briefNaturalApproximate(java.time.Duration.ofSeconds(expires.getSeconds()));
+          TextComponent.of(
+              ComponentRenderers.toLegacyText(
+                  PeriodFormats.briefNaturalApproximate(
+                      java.time.Duration.ofSeconds(expires.getSeconds())),
+                  Bukkit.getConsoleSender()));
       lines.add(
-          new PersonalizedTranslatable("moderation.screen.expires", timeLeft)
-              .getPersonalizedText()
-              .color(ChatColor.GRAY));
-      lines.add(Components.blank());
+          TranslatableComponent.of("moderation.screen.expires", TextColor.GRAY).args(timeLeft));
+      lines.add(TextComponent.empty());
     }
 
-    // Staff sign-off
-    lines.add(
-        new PersonalizedTranslatable("moderation.screen.signoff", punisher)
-            .getPersonalizedText()
-            .color(ChatColor.GRAY)); // The sign-off of who performed the punishment
+    // Staff sign-off - who performed the punishment
+    lines.add(TranslatableComponent.of("moderation.screen.signoff", TextColor.GRAY).args(punisher));
 
     // Link to rules for review by player
     if (PGMConfig.Moderation.isRuleLinkVisible()) {
-      Component rules = new PersonalizedText(PGMConfig.Moderation.getRulesLink());
+      Component rules = TextComponent.of(PGMConfig.Moderation.getRulesLink());
 
-      lines.add(Components.blank());
+      lines.add(TextComponent.empty());
       lines.add(
-          new PersonalizedTranslatable("moderation.screen.rulesLink", rules)
-              .getPersonalizedText()
-              .color(ChatColor.GRAY)); // A link to the rules
+          TranslatableComponent.of("moderation.screen.rulesLink", TextColor.GRAY)
+              .args(rules)); // Link to rules
     }
 
     // Configurable last line (for appeal message or etc)
     if (PGMConfig.Moderation.isAppealVisible() && type.equals(PunishmentType.BAN)) {
-      lines.add(Components.blank());
-      lines.add(new PersonalizedText(PGMConfig.Moderation.getAppealMessage()));
+      lines.add(TextComponent.empty());
+      lines.add(TextComponent.of(PGMConfig.Moderation.getAppealMessage()));
     }
 
-    lines.add(Components.blank());
+    lines.add(TextComponent.empty());
     lines.add(footer); // Footer line - END
 
-    return Components.join(new PersonalizedText("\n" + ChatColor.RESET), lines).toLegacyText();
+    return TextTranslations.translateLegacy(
+        TextComponent.join(TextComponent.of("\n" + ChatColor.RESET), lines),
+        null); // TODO add viewer
   }
 
   /*
    * Sends a formatted title and plays a sound warning a user of their actions
    */
   private void sendWarning(MatchPlayer target, String reason) {
-    Component titleWord =
-        new PersonalizedTranslatable("misc.warning")
-            .getPersonalizedText()
-            .color(ChatColor.DARK_RED);
-    Component title = new PersonalizedText(WARN_SYMBOL, titleWord, WARN_SYMBOL);
-    Component subtitle = formatPunishmentReason(reason).color(ChatColor.GOLD);
+    Component titleWord = TranslatableComponent.of("misc.warning", TextColor.DARK_RED);
+    Component title =
+        TextComponent.builder().append(WARN_SYMBOL).append(titleWord).append(WARN_SYMBOL).build();
+    Component subtitle = formatPunishmentReason(reason).color(TextColor.GOLD);
 
-    target.showTitle(title, subtitle, 5, 200, 10);
+    // TODO: Upgrade show title to new text
+    tc.oc.pgm.util.component.Component oldTitle =
+        new PersonalizedText(TextTranslations.translateLegacy(title, target.getBukkit()));
+    tc.oc.pgm.util.component.Component oldSubTitle =
+        new PersonalizedText(TextTranslations.translateLegacy(subtitle, target.getBukkit()));
+
+    target.showTitle(oldTitle, oldSubTitle, 5, 200, 10);
     target.playSound(WARN_SOUND);
   }
 
@@ -897,7 +856,7 @@ public class ModerationCommands implements Listener {
         event.getType(),
         event.getPlayer().getMatch(),
         event.getSender(),
-        event.getPlayer().getStyledName(NameStyle.CONCISE),
+        event.getPlayer().getName(NameStyle.CONCISE),
         event.getReason(),
         event.isSilent(),
         event.getDuration());
@@ -919,27 +878,24 @@ public class ModerationCommands implements Listener {
     if (length != null && !length.isZero()) {
       String time =
           ComponentRenderers.toLegacyText(
-              PeriodFormats.briefNaturalApproximate(
-                  java.time.Duration.ofSeconds(length.getSeconds())),
+              PeriodFormats.briefNaturalApproximate(Duration.ofSeconds(length.getSeconds())),
               sender);
       prefix =
           type.getPunishmentPrefix(
               time.lastIndexOf('s') != -1
-                  ? new PersonalizedText(time.substring(0, time.lastIndexOf('s')))
-                      .color(ChatColor.GOLD)
-                  : Components.blank());
+                  ? TextComponent.of(time.substring(0, time.lastIndexOf('s')), TextColor.GOLD)
+                  : TextComponent.empty());
     }
 
-    Component reasonMsg = ModerationCommands.formatPunishmentReason(reason);
+    Component reasonMsg = formatPunishmentReason(reason);
     Component formattedMsg =
-        new PersonalizedText(
-            UsernameFormatUtils.formatStaffName(sender, match),
-            BROADCAST_DIV,
-            prefix,
-            BROADCAST_DIV,
-            target,
-            BROADCAST_DIV,
-            reasonMsg);
+        UsernameFormatUtils.formatStaffName(sender, match)
+            .append(BROADCAST_DIV)
+            .append(prefix)
+            .append(BROADCAST_DIV)
+            .append(target)
+            .append(BROADCAST_DIV)
+            .append(reasonMsg);
 
     if (!silent) {
       match.sendMessage(formattedMsg);
@@ -980,12 +936,14 @@ public class ModerationCommands implements Listener {
 
     public Component getHoverMessage() {
       Component timeAgo =
-          PeriodFormats.relativePastApproximate(java.time.Instant.ofEpochMilli(time.toEpochMilli()))
-              .color(ChatColor.DARK_AQUA);
-
-      return new PersonalizedTranslatable("moderation.similarIP.hover", getPunisher(), timeAgo)
-          .getPersonalizedText()
-          .color(ChatColor.GRAY);
+          TextComponent.of(
+              ComponentRenderers.toLegacyText(
+                  PeriodFormats.relativePastApproximate(
+                          java.time.Instant.ofEpochMilli(time.toEpochMilli()))
+                      .color(ChatColor.DARK_AQUA),
+                  Bukkit.getConsoleSender()));
+      return TranslatableComponent.of("moderation.similarIP.hover", TextColor.GRAY)
+          .args(getPunisher(), timeAgo);
     }
   }
 
@@ -1000,7 +958,7 @@ public class ModerationCommands implements Listener {
             target,
             reason,
             expires != null ? Date.from(expires) : null,
-            ComponentRenderers.toLegacyText(source, Bukkit.getConsoleSender()));
+            TextTranslations.translateLegacy(source, null));
   }
 
   // On login of accounts whose IP match a recently banned player, alert staff.
@@ -1048,10 +1006,7 @@ public class ModerationCommands implements Listener {
               : null;
 
       return formatPunishmentScreen(
-          type,
-          new PersonalizedText(ban.getSource()).color(ChatColor.AQUA),
-          ban.getReason(),
-          length);
+          type, TextComponent.of(ban.getSource(), TextColor.AQUA), ban.getReason(), length);
     }
     return null;
   }
@@ -1066,13 +1021,11 @@ public class ModerationCommands implements Listener {
 
   private Component formatAltAccountBroadcast(BannedAccountInfo info, MatchPlayer player) {
     Component message =
-        new PersonalizedTranslatable(
-                "moderation.similarIP.loginEvent",
-                player.getStyledName(NameStyle.FANCY),
-                new PersonalizedText(info.getUserName()).color(ChatColor.DARK_AQUA))
-            .getPersonalizedText()
-            .color(ChatColor.GRAY);
-    return message.hoverEvent(HoverEvent.Action.SHOW_TEXT, info.getHoverMessage().render());
+        TranslatableComponent.of("moderation.similarIP.loginEvent")
+            .args(
+                player.getName(NameStyle.FANCY),
+                TextComponent.of(info.getUserName(), TextColor.DARK_AQUA));
+    return message.hoverEvent(HoverEvent.of(Action.SHOW_TEXT, info.getHoverMessage()));
   }
 
   // Force vanished players to silent broadcast

--- a/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ModerationCommands.java
@@ -169,46 +169,18 @@ public class ModerationCommands implements Listener {
       aliases = {"freeze", "fz", "f"},
       usage = "<player>",
       flags = "s",
-      desc = "Freeze a player",
+      desc = "Toggle a player's frozen state",
       perms = Permissions.FREEZE)
   public void freeze(CommandSender sender, Match match, Player target, @Switch('s') boolean silent)
       throws CommandException {
-    setFreeze(sender, match, target, true, silent);
+    setFreeze(sender, match, target, silent);
   }
 
-  @Command(
-      aliases = {"unfreeze", "uf"},
-      usage = "<player>",
-      flags = "s",
-      desc = "Unfreeze a player",
-      perms = Permissions.FREEZE)
-  public void unFreeze(
-      CommandSender sender, Match match, Player target, @Switch('s') boolean silent)
-      throws CommandException {
-    setFreeze(sender, match, target, false, silent);
-  }
-
-  private void setFreeze(
-      CommandSender sender, Match match, Player target, boolean freeze, boolean silent)
-      throws CommandException {
+  private void setFreeze(CommandSender sender, Match match, Player target, boolean silent) {
     FreezeMatchModule fmm = match.getModule(FreezeMatchModule.class);
     MatchPlayer player = match.getPlayer(target);
-
-    Component alreadyFrozen =
-        TranslatableComponent.of("moderation.freeze.alreadyFrozen", TextColor.GRAY)
-            .args(match.getPlayer(target).getName(NameStyle.FANCY));
-    Component alreadyThawed =
-        TranslatableComponent.of("moderation.freeze.alreadyThawed", TextColor.GRAY)
-            .args(match.getPlayer(target).getName(NameStyle.FANCY));
-
     if (player != null) {
-      if (fmm.isFrozen(player) && freeze) {
-        throw new CommandException(TextTranslations.translateLegacy(alreadyFrozen, sender));
-      } else if (!fmm.isFrozen(player) && !freeze) {
-        throw new CommandException(TextTranslations.translateLegacy(alreadyThawed, sender));
-      } else {
-        fmm.setFrozen(sender, player, freeze, silent);
-      }
+      fmm.setFrozen(sender, player, !fmm.isFrozen(player), silent);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -246,7 +246,8 @@ public class ReportCommands {
 
     private Component getUsername(UUID uuid, Match match) {
       MatchPlayer player = match.getPlayer(targetUUID);
-      Component name = TextComponent.of("Unknown", TextColor.AQUA, TextDecoration.ITALIC);
+      Component name =
+          TranslatableComponent.of("misc.unknown", TextColor.AQUA, TextDecoration.ITALIC);
       if (match.getPlayer(targetUUID) != null) {
         name = player.getName(NameStyle.FANCY);
       } else {

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -17,25 +17,32 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.event.HoverEvent;
+import net.kyori.text.event.HoverEvent.Action;
+import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.HoverEvent.Action;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.events.PlayerReportEvent;
+import tc.oc.pgm.community.events.PlayerReportEvent;
 import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.chat.Sound;
-import tc.oc.pgm.util.component.Component;
 import tc.oc.pgm.util.component.ComponentRenderers;
 import tc.oc.pgm.util.component.ComponentUtils;
 import tc.oc.pgm.util.component.PeriodFormats;
-import tc.oc.pgm.util.component.types.PersonalizedText;
 import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.text.TextTranslations;
 
 public class ReportCommands {
 
@@ -50,79 +57,66 @@ public class ReportCommands {
   private final Cache<UUID, Report> RECENT_REPORTS =
       CacheBuilder.newBuilder().expireAfterWrite(REPORT_EXPIRE_HOURS, TimeUnit.HOURS).build();
 
+  private final Datastore database;
+
+  public ReportCommands(Datastore database) {
+    this.database = database;
+  }
+
   @Command(
       aliases = {"report"},
       usage = "<player> <reason>",
       desc = "Report a player who is breaking the rules")
-  public void report(
-      CommandSender commandSender,
-      MatchPlayer matchPlayer,
-      Match match,
-      Player player,
-      @Text String reason)
+  public void report(MatchPlayer sender, Match match, Player player, @Text String reason)
       throws CommandException {
-    if (!commandSender.hasPermission(Permissions.STAFF) && commandSender instanceof Player) {
+    if (!sender.getBukkit().hasPermission(Permissions.STAFF)) {
       // Check for cooldown
-      Instant lastReport = LAST_REPORT_SENT.getIfPresent(matchPlayer.getId());
+      Instant lastReport = LAST_REPORT_SENT.getIfPresent(sender.getId());
       if (lastReport != null) {
         Duration timeSinceReport = Duration.between(lastReport, Instant.now());
         long secondsRemaining = REPORT_COOLDOWN_SECONDS - timeSinceReport.getSeconds();
         if (secondsRemaining > 0) {
-          Component secondsComponent = new PersonalizedText(Long.toString(secondsRemaining));
-          Component secondsLeftComponent =
-              new PersonalizedTranslatable(
+          TextComponent secondsComponent = TextComponent.of(Long.toString(secondsRemaining));
+          TranslatableComponent secondsLeftComponent =
+              TranslatableComponent.of(
                       secondsRemaining != 1 ? "misc.seconds" : "misc.second", secondsComponent)
-                  .getPersonalizedText()
-                  .color(ChatColor.AQUA);
-          commandSender.sendMessage(
-              new PersonalizedTranslatable("command.cooldown", secondsLeftComponent)
-                  .getPersonalizedText()
-                  .color(ChatColor.RED));
+                  .color(TextColor.AQUA);
+          sender.sendWarning(TranslatableComponent.of("command.cooldown", secondsLeftComponent));
           return;
         }
       } else {
         // Player has no cooldown, so add one
-        LAST_REPORT_SENT.put(matchPlayer.getId(), Instant.now());
+        LAST_REPORT_SENT.put(sender.getId(), Instant.now());
       }
     }
 
     MatchPlayer accused = match.getPlayer(player);
-    PlayerReportEvent event = new PlayerReportEvent(commandSender, accused, reason);
+    PlayerReportEvent event = new PlayerReportEvent(sender, accused, reason);
     match.callEvent(event);
 
     if (event.isCancelled()) {
       if (event.getCancelMessage() != null) {
-        commandSender.sendMessage(event.getCancelMessage());
+        sender.sendMessage(event.getCancelMessage());
       }
       return;
     }
 
-    commandSender.sendMessage(
-        new PersonalizedText(
-            new PersonalizedText(new PersonalizedTranslatable("misc.thankYou"), ChatColor.GREEN),
-            new PersonalizedText(" "),
-            new PersonalizedText(
-                new PersonalizedTranslatable("moderation.report.acknowledge"), ChatColor.GOLD)));
+    TranslatableComponent thanks =
+        TranslatableComponent.of("misc.thankYou", TextColor.GREEN)
+            .append(TextComponent.space())
+            .append(TranslatableComponent.of("moderation.report.acknowledge", TextColor.GOLD));
+    sender.sendMessage(thanks);
 
     final Component component =
-        new PersonalizedTranslatable(
-            "moderation.report.notify",
-            matchPlayer == null
-                ? new PersonalizedText("Console", ChatColor.AQUA, ChatColor.ITALIC)
-                : matchPlayer.getStyledName(NameStyle.FANCY),
-            accused.getStyledName(NameStyle.FANCY),
-            new PersonalizedText(reason.trim(), ChatColor.WHITE));
+        TranslatableComponent.of("moderation.report.notify", TextColor.YELLOW)
+            .args(
+                sender == null ? UsernameFormatUtils.CONSOLE_NAME : sender.getName(NameStyle.FANCY),
+                accused.getName(NameStyle.FANCY),
+                TextComponent.of(reason.trim(), TextColor.WHITE));
 
-    RECENT_REPORTS.put(
-        UUID.randomUUID(),
-        new Report(
-            player.getName(),
-            reason,
-            accused.getStyledName(NameStyle.FANCY),
-            matchPlayer.getStyledName(NameStyle.CONCISE)));
+    RECENT_REPORTS.put(UUID.randomUUID(), new Report(accused.getId(), sender.getId(), reason));
 
-    ChatDispatcher.broadcastAdminChatMessage(
-        new PersonalizedText(component, ChatColor.YELLOW), match, Optional.of(REPORT_NOTIFY_SOUND));
+    ChatDispatcher.broadcastAdminChatMessage(component, match, Optional.of(REPORT_NOTIFY_SOUND));
   }
 
   @Command(
@@ -134,6 +128,7 @@ public class ReportCommands {
   public void reportHistory(
       Audience audience,
       CommandSender sender,
+      Match match,
       @Default("1") int page,
       @Fallback(Type.NULL) @Switch('t') String target)
       throws CommandException {
@@ -149,98 +144,115 @@ public class ReportCommands {
     if (target != null) {
       reportList =
           reportList.stream()
-              .filter(r -> r.getId().equalsIgnoreCase(target))
+              .filter(r -> r.getTargetName(match).equalsIgnoreCase(target))
               .collect(Collectors.toList());
     }
 
     Collections.sort(reportList); // Sort list
     Collections.reverse(reportList); // Reverse so most recent show up first
 
-    Component headerResultCount =
-        new PersonalizedText(Long.toString(reportList.size())).color(ChatColor.RED);
+    Component headerResultCount = TextComponent.of(Long.toString(reportList.size()), TextColor.RED);
 
     int perPage = 6;
     int pages = (reportList.size() + perPage - 1) / perPage;
 
     Component pageNum =
-        new PersonalizedTranslatable(
-                "command.simplePageHeader",
-                new PersonalizedText(Integer.toString(page)).color(ChatColor.RED),
-                new PersonalizedText(Integer.toString(pages)).color(ChatColor.RED))
-            .add(ChatColor.AQUA);
+        TranslatableComponent.of("command.simplePageHeader", TextColor.AQUA)
+            .args(
+                TextComponent.of(Integer.toString(page), TextColor.RED),
+                TextComponent.of(Integer.toString(pages), TextColor.RED));
 
     Component header =
-        new PersonalizedText(
-            new PersonalizedTranslatable("moderation.reports.header", headerResultCount, pageNum)
-                .getPersonalizedText()
-                .color(ChatColor.GRAY),
-            new PersonalizedText(" ("),
-            headerResultCount,
-            new PersonalizedText(") » "),
-            pageNum);
+        TranslatableComponent.of("moderation.reports.header", TextColor.GRAY)
+            .args(headerResultCount, pageNum)
+            .append(
+                TextComponent.of(" (")
+                    .append(headerResultCount)
+                    .append(TextComponent.of(") » "))
+                    .append(pageNum));
 
     Component formattedHeader =
-        new PersonalizedText(
+        TextComponent.of(
             ComponentUtils.horizontalLineHeading(
-                ComponentRenderers.toLegacyText(header, sender), ChatColor.DARK_GRAY));
+                TextTranslations.translateLegacy(header, sender), ChatColor.DARK_GRAY));
 
     new PrettyPaginatedComponentResults<Report>(formattedHeader, perPage) {
       @Override
       public Component format(Report data, int index) {
 
         Component reporter =
-            new PersonalizedTranslatable("moderation.reports.hover", data.getSenderName())
-                .color(ChatColor.GRAY);
+            TranslatableComponent.of("moderation.reports.hover", TextColor.GRAY)
+                .args(data.getSenderComponent(match));
 
         Component timeAgo =
-            PeriodFormats.relativePastApproximate(
-                    java.time.Instant.ofEpochMilli(data.getTimeSent().toEpochMilli()))
-                .color(ChatColor.DARK_AQUA);
+            TextComponent.of(
+                ComponentRenderers.toLegacyText(
+                    PeriodFormats.relativePastApproximate(
+                            Instant.ofEpochMilli(data.getTimeSent().toEpochMilli()))
+                        .color(ChatColor.DARK_AQUA),
+                    sender));
 
-        return new PersonalizedText(
-            new PersonalizedText(timeAgo.render(sender))
-                .hoverEvent(Action.SHOW_TEXT, reporter.render(sender)),
-            new PersonalizedText(": ").color(ChatColor.GRAY),
-            data.getTargetName(),
-            new PersonalizedText(" « ").color(ChatColor.YELLOW),
-            new PersonalizedText(data.getReason()).italic(true).color(ChatColor.WHITE));
+        return TextComponent.builder()
+            .append(timeAgo.hoverEvent(HoverEvent.of(Action.SHOW_TEXT, reporter)))
+            .append(": ", TextColor.GRAY)
+            .append(data.getTargetComponent(match))
+            .append(" « ", TextColor.YELLOW)
+            .append(data.getReason(), TextColor.WHITE, TextDecoration.ITALIC)
+            .build();
       }
     }.display(audience, reportList, page);
   }
 
-  public static class Report implements Comparable<Report> {
-    private final String id;
+  private class Report implements Comparable<Report> {
+    private final UUID targetUUID;
+    private final UUID senderUUID;
     private final String reason;
-    private final Component targetName;
-    private final Component sender;
     private final Instant timeSent;
 
-    public Report(String id, String reason, Component targetName, Component sender) {
-      this.id = id;
+    public Report(UUID target, UUID sender, String reason) {
+      this.targetUUID = target;
+      this.senderUUID = sender;
       this.reason = reason;
-      this.targetName = targetName;
-      this.sender = sender;
       this.timeSent = Instant.now();
     }
 
-    public String getId() {
-      return id;
+    public UUID getTarget() {
+      return targetUUID;
+    }
+
+    public UUID getSender() {
+      return senderUUID;
     }
 
     public String getReason() {
-      return reason;
-    }
-
-    public Component getTargetName() {
-      return targetName;
-    }
-
-    public Component getSenderName() {
-      return sender;
+      return reason.trim();
     }
 
     public Instant getTimeSent() {
       return timeSent;
+    }
+
+    public String getTargetName(Match match) {
+      return database.getUsername(targetUUID).getName();
+    }
+
+    public Component getTargetComponent(Match match) {
+      return getUsername(getTarget(), match);
+    }
+
+    public Component getSenderComponent(Match match) {
+      return getUsername(getSender(), match);
+    }
+
+    private Component getUsername(UUID uuid, Match match) {
+      MatchPlayer player = match.getPlayer(targetUUID);
+      Component name = TextComponent.of("Unknown", TextColor.AQUA, TextDecoration.ITALIC);
+      if (match.getPlayer(targetUUID) != null) {
+        name = player.getName(NameStyle.FANCY);
+      } else {
+        name = TextComponent.of(database.getUsername(targetUUID).getName(), TextColor.DARK_AQUA);
+      }
+      return name;
     }
 
     @Override

--- a/core/src/main/java/tc/oc/pgm/community/events/PlayerReportEvent.java
+++ b/core/src/main/java/tc/oc/pgm/community/events/PlayerReportEvent.java
@@ -1,8 +1,7 @@
-package tc.oc.pgm.events;
+package tc.oc.pgm.community.events;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import tc.oc.pgm.api.event.ExtendedCancellable;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -10,17 +9,17 @@ import tc.oc.pgm.api.player.MatchPlayer;
 /** Called immediately AFTER a player runs the report command. */
 public class PlayerReportEvent extends ExtendedCancellable {
 
-  private final CommandSender sender;
+  private final MatchPlayer sender;
   private final MatchPlayer player;
   private final String reason;
 
-  public PlayerReportEvent(CommandSender sender, MatchPlayer player, String reason) {
+  public PlayerReportEvent(MatchPlayer sender, MatchPlayer player, String reason) {
     this.sender = checkNotNull(sender);
     this.player = checkNotNull(player);
     this.reason = checkNotNull(reason);
   }
 
-  public CommandSender getSender() {
+  public MatchPlayer getSender() {
     return sender;
   }
 

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -78,10 +78,6 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
   @Override
   public boolean setVanished(MatchPlayer player, boolean vanish, boolean quiet) {
-    if (isVanished(player.getId()) == vanish) {
-      return false;
-    }
-
     // Keep track of the UUID and apply/remove META data, so we can detect vanish status from other
     // projects (i.e utils)
     if (vanish) {
@@ -108,7 +104,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
     match.callEvent(new PlayerVanishEvent(player, vanish));
 
-    return true;
+    return isVanished(player.getId());
   }
 
   private void addVanished(MatchPlayer player) {
@@ -125,26 +121,14 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
   /* Commands */
   @Command(
-      aliases = {"vanish", "disappear", "v"},
-      desc = "Vanish from the server",
+      aliases = {"vanish", "v"},
+      desc = "Toggle vanish status",
       perms = Permissions.VANISH)
   public void vanish(MatchPlayer sender, @Switch('s') boolean silent) throws CommandException {
-    if (setVanished(sender, true, silent)) {
-      sender.sendMessage(TranslatableComponent.of("vanish.activate").color(TextColor.GREEN));
+    if (setVanished(sender, !isVanished(sender.getId()), silent)) {
+      sender.sendWarning(TranslatableComponent.of("vanish.activate").color(TextColor.GREEN));
     } else {
-      sender.sendWarning(TranslatableComponent.of("vanish.activate.already"));
-    }
-  }
-
-  @Command(
-      aliases = {"unvanish", "appear", "uv"},
-      desc = "Return to the server",
-      perms = Permissions.VANISH)
-  public void unVanish(MatchPlayer sender, @Switch('s') boolean silent) throws CommandException {
-    if (setVanished(sender, false, silent)) {
-      sender.sendMessage(TranslatableComponent.of("vanish.deactivate").color(TextColor.RED));
-    } else {
-      sender.sendWarning(TranslatableComponent.of("vanish.deactivate.already"));
+      sender.sendWarning(TranslatableComponent.of("vanish.deactivate").color(TextColor.RED));
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -96,9 +96,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
     final Match match = player.getMatch();
 
     // Ensure player is an observer
-    if (!player.getParty().isObserving()) {
-      match.setParty(player, match.getDefaultParty());
-    }
+    match.setParty(player, match.getDefaultParty());
 
     // Set vanish status in match player
     player.setVanished(vanish);

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -10,9 +10,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
-import net.md_5.bungee.api.ChatColor;
+import net.kyori.text.format.TextDecoration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -26,13 +28,8 @@ import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.VanishManager;
 import tc.oc.pgm.api.player.event.MatchPlayerAddEvent;
-import tc.oc.pgm.api.setting.SettingKey;
-import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.community.events.PlayerVanishEvent;
 import tc.oc.pgm.listeners.PGMListener;
-import tc.oc.pgm.util.component.Component;
-import tc.oc.pgm.util.component.types.PersonalizedText;
-import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
 
 public class VanishManagerImpl implements VanishManager, Listener {
 
@@ -106,7 +103,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
     // Broadcast join/quit message
     if (!quiet) {
-      PGMListener.announceJoinOrLeave(player, !vanish);
+      PGMListener.announceJoinOrLeave(player, !vanish, false);
     }
 
     match.callEvent(new PlayerVanishEvent(player, vanish));
@@ -118,7 +115,6 @@ public class VanishManagerImpl implements VanishManager, Listener {
     if (!isVanished(player.getId())) {
       this.vanishedPlayers.add(player.getId());
       player.getBukkit().setMetadata(VANISH_KEY, VANISH_VALUE);
-      player.getSettings().setValue(SettingKey.CHAT, SettingValue.CHAT_ADMIN);
     }
   }
 
@@ -166,13 +162,12 @@ public class VanishManagerImpl implements VanishManager, Listener {
   }
 
   private void sendHotbarVanish(MatchPlayer player, boolean flashColor) {
-    PersonalizedText warning =
-        new PersonalizedText(" \u26a0 ", flashColor ? ChatColor.YELLOW : ChatColor.GOLD);
+    Component warning =
+        TextComponent.of(" \u26a0 ", flashColor ? TextColor.YELLOW : TextColor.GOLD);
     Component vanish =
-        new PersonalizedTranslatable("vanish.hotbar")
-            .getPersonalizedText()
-            .color(ChatColor.RED)
-            .bold(true);
-    player.sendHotbarMessage(new PersonalizedText(warning, vanish, warning));
+        TranslatableComponent.of("vanish.hotbar", TextColor.RED, TextDecoration.BOLD);
+    Component message =
+        TextComponent.builder().append(warning).append(vanish).append(warning).build();
+    player.showHotbar(message);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -140,7 +140,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
           return true;
 
         case VANISHED:
-          joining.sendWarning(new PersonalizedTranslatable("command.gameplay.join.vanish"), false);
+          joining.sendWarning(new PersonalizedTranslatable("join.err.vanish"), false);
           return true;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/rotation/DisabledMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/DisabledMapPool.java
@@ -22,4 +22,7 @@ public class DisabledMapPool extends MapPool {
   public MapInfo getNextMap() {
     return null;
   }
+
+  @Override
+  public void resetNextMap() {}
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -99,6 +99,9 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
   @Override
   public void setNextMap(MapInfo map) {}
 
+  @Override
+  public void resetNextMap() {}
+
   /**
    * Called when this map pool is going to be switched out
    *

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -65,7 +65,13 @@ public class MapPoolManager implements MapOrder {
   }
 
   public @Nullable String getNextMapForPool(String poolName) {
-    return database.getMapActivity(poolName).getMapName();
+    String mapName = database.getMapActivity(poolName).getMapName();
+    if (mapName != null) {
+      PGM.get()
+          .getLogger()
+          .log(Level.INFO, String.format("%s was found in map activity as the next map.", mapName));
+    }
+    return mapName;
   }
 
   private void loadMapPools() {
@@ -88,7 +94,6 @@ public class MapPoolManager implements MapOrder {
     if (activeMapPool == null) {
       logger.log(Level.WARNING, "No active map pool was found, defaulting to first dynamic pool.");
       activeMapPool = mapPools.stream().filter(mp -> mp.isDynamic()).findFirst().orElse(null);
-
       if (activeMapPool == null) {
         logger.log(Level.SEVERE, "Failed to find any dynamic map pool!");
       }
@@ -191,6 +196,13 @@ public class MapPoolManager implements MapOrder {
   public void setNextMap(MapInfo map) {
     overriderMap = map;
     activeMapPool.setNextMap(map); // Notify pool a next map has been set
+  }
+
+  @Override
+  public void resetNextMap() {
+    if (overriderMap != null) {
+      overriderMap = null;
+    }
   }
 
   public Optional<MapPool> getAppropriateDynamicPool(Match match) {

--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
@@ -72,4 +72,11 @@ public class RandomMapOrder implements MapOrder {
     // Set next maps are sent to the front of the deque
     deque.addFirst(new WeakReference<>(map));
   }
+
+  @Override
+  public void resetNextMap() {
+    if (deque.pollFirst() != null) {
+      deque.removeFirst();
+    }
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
@@ -27,4 +27,9 @@ public class RandomMapPool extends MapPool {
   public void setNextMap(MapInfo map) {
     order.setNextMap(map);
   }
+
+  @Override
+  public void resetNextMap() {
+    order.resetNextMap();
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
+++ b/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
@@ -4,8 +4,8 @@ import app.ashcon.intake.CommandException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import net.kyori.text.Component;
 import tc.oc.pgm.util.chat.Audience;
-import tc.oc.pgm.util.component.Component;
 
 public abstract class PrettyPaginatedComponentResults<T> {
 

--- a/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
+++ b/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
@@ -1,12 +1,14 @@
 package tc.oc.pgm.util;
 
-import net.md_5.bungee.api.ChatColor;
+import net.kyori.text.Component;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.util.component.Component;
-import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
+import tc.oc.pgm.community.commands.ModerationCommands;
 import tc.oc.pgm.util.named.NameStyle;
 
 /**
@@ -15,16 +17,14 @@ import tc.oc.pgm.util.named.NameStyle;
  */
 public class UsernameFormatUtils {
 
-  private static final Component CONSOLE_NAME =
-      new PersonalizedTranslatable("console")
-          .getPersonalizedText()
-          .color(ChatColor.DARK_AQUA)
-          .italic(true);
+  public static final Component CONSOLE_NAME =
+      TranslatableComponent.of("misc.console", TextColor.DARK_AQUA)
+          .decoration(TextDecoration.ITALIC, true);
 
   public static Component formatStaffName(CommandSender sender, Match match) {
     if (sender != null && sender instanceof Player) {
       MatchPlayer matchPlayer = match.getPlayer((Player) sender);
-      if (matchPlayer != null) return matchPlayer.getStyledName(NameStyle.FANCY);
+      if (matchPlayer != null) return matchPlayer.getName(NameStyle.FANCY);
     }
     return CONSOLE_NAME;
   }

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -73,7 +73,8 @@ command.list.teams = Teams:
 
 command.list.participants = Participants
 
-command.message.noReply = Did not find a message to reply to, use /msg
+# {0} = command name
+command.message.noReply = Did not find a message to reply to, use {0}
 
 # {0} = player name
 command.message.blocked = {0} is not accepting messages at this time.

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -72,3 +72,8 @@ command.list.online = Total Online: {0}
 command.list.teams = Teams:
 
 command.list.participants = Participants
+
+command.message.noReply = Did not find a message to reply to, use /msg
+
+# {0} = player name
+command.message.blocked = {0} is not accepting messages at this time.

--- a/util/src/main/i18n/templates/join.properties
+++ b/util/src/main/i18n/templates/join.properties
@@ -51,6 +51,8 @@ join.err.full = Sorry, the match is full
 # {0} = team name (e.g. "Blue Team")
 join.err.full.team = Sorry, {0} is completely full
 
+join.err.vanish = You cannot join the match while vanished
+
 leave.ok.priorityKick = You were kicked from the match to make room for a premium player
 
 # {0} = team name (e.g. "Blue Team")

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -50,6 +50,12 @@ map.setNext = Next map set to {0} by {1}
 
 map.setNext.confirm = You may not set the next map when a restart is queued. Use -f to override.
 
+# {0} = player name (who unset the map)
+# {1} = Name of map that was unset.
+map.setNext.revert = {0} has removed {1} as the next map.
+
+map.setNext.none = No map has been set next.
+
 map.noNextMap = No next map
 
 # {0} = map name
@@ -89,9 +95,14 @@ pool.title = Map Pools
 
 pool.noPoolMatch = No map pools matched query
 
+pool.noDynamic = No dynamic pool could be found.
+
 pool.noRotation = No rotation currently in use
 
 pool.noMapPools = No loaded map pools
+
+# {0} = map pool name (e.g. "Mega")
+pool.matching = {0} is already the current map pool.
 
 pool.mapPoolsDisabled = Map pools are currently disabled
 

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -51,10 +51,8 @@ map.setNext = Next map set to {0} by {1}
 map.setNext.confirm = You may not set the next map when a restart is queued. Use -f to override.
 
 # {0} = player name (who unset the map)
-# {1} = Name of map that was unset.
-map.setNext.revert = {0} has removed {1} as the next map.
-
-map.setNext.none = No map has been set next.
+# {1} = name of map that was unset
+map.setNext.revert = {0} has removed {1} as the next map
 
 map.noNextMap = No next map
 
@@ -95,14 +93,14 @@ pool.title = Map Pools
 
 pool.noPoolMatch = No map pools matched query
 
-pool.noDynamic = No dynamic pool could be found.
+pool.noDynamic = No dynamic pool could be found
 
 pool.noRotation = No rotation currently in use
 
 pool.noMapPools = No loaded map pools
 
 # {0} = map pool name (e.g. "Mega")
-pool.matching = {0} is already the current map pool.
+pool.matching = {0} is already the current map pool
 
 pool.mapPoolsDisabled = Map pools are currently disabled
 

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -147,3 +147,6 @@ admin.start.matchFinished = Match has finished and may not be resumed.
 admin.start.unknownState = Match could not be started at this time.
 
 admin.end.unknownError = Match could not be ended at this time.
+
+admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
+

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -57,6 +57,9 @@ misc.timeRemaining = Time Remaining: {0}
 # {0} = player name
 misc.createdBy = Created by {0}
 
+# {0} = player name
+misc.by = by {0}
+
 # {0} = some map or gamemode name
 misc.playing = Playing {0}
 

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -171,10 +171,6 @@ vanish.activate = You have vanished!
 
 vanish.deactivate = You are now visible!
 
-vanish.activate.already = You are already vanished
-
-vanish.deactivate.already = You are not vanished
-
 vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -37,7 +37,7 @@ moderation.screen.signoff = Issued by {0}
 # {0} = duration (e.g. "2 weeks")
 moderation.screen.expires = Expires in {0}
 
-moderation.mute.message = You have been muted and are unable to send chat messages.
+moderation.mute.message = You have been muted and are unable to send chat messages
 
 moderation.mute.list = Muted Players
 
@@ -47,7 +47,7 @@ moderation.mute.none = There are no muted players online!
 moderation.mute.hover = Click to unmute {0}
 
 # {0} = player name
-moderation.mute.target = {0} is muted and unable to receive messages.
+moderation.mute.target = {0} is muted and unable to receive messages
 
 # {0} = player name
 moderation.mute.existing = {0} is already muted!
@@ -73,17 +73,17 @@ moderation.alts.header = Alt-Accounts
 moderation.alts.noAlts = {0} has no alternate accounts online.
 
 # {0} = ip address (e.g. "1.2.3.4")
-moderation.ipBan.invalidIP = {0} is not a valid IP address.
+moderation.ipBan.invalidIP = {0} is not a valid IP address
 
 # {0} = player name
-moderation.ipBan.banned = {0} has been IP banned.
+moderation.ipBan.banned = {0} has been IP banned
 
 # {0} = player name or ip address (e.g. "Notch" or "1.2.3.4")
 # {1} = number of alternate accounts
-moderation.ipBan.bannedWithAlts = {0} has been IP banned along with {1} online alts.
+moderation.ipBan.bannedWithAlts = {0} has been IP banned along with {1} online alts
 
 # {0} = player name
-moderation.records.lookupNone = {0} has no punishment record.
+moderation.records.lookupNone = {0} has no punishment record
 
 moderation.records.header = Punishment Info
 
@@ -92,7 +92,7 @@ moderation.records.reason = Reason: {0}
 
 # {0} = player name
 # {1} = another player name
-moderation.similarIP.loginEvent = {0} has a similar IP to banned player {1}.
+moderation.similarIP.loginEvent = {0} has a similar IP to banned player {1}
 
 # {0} = player name
 # {1} = past duration (e.g. "5 minutes ago")
@@ -114,16 +114,16 @@ moderation.freeze.itemName = Player Freezer
 
 moderation.freeze.itemDescription = Right-click a player to freeze/thaw them
 
-moderation.freeze.notEnabled = Freeze is not enabled.
+moderation.freeze.notEnabled = Freeze is not enabled
 
 # {0} = player name
 moderation.freeze.exempt = {0} may not be frozen
 
 # {0} = player name
-moderation.freeze.alreadyFrozen = {0} is already frozen.
+moderation.freeze.alreadyFrozen = {0} is already frozen
 
 # {0} = player name
-moderation.freeze.alreadyThawed = {0} is not frozen.
+moderation.freeze.alreadyThawed = {0} is not frozen
 
 # {0} = number of players
 # {1} = list of player names (e.g. "Alice, Bob, and Jerry")
@@ -171,11 +171,11 @@ vanish.activate = You have vanished!
 
 vanish.deactivate = You are now visible!
 
-vanish.activate.already = You are already vanished.
+vanish.activate.already = You are already vanished
 
-vanish.deactivate.already = You are not vanished.
+vanish.deactivate.already = You are not vanished
 
-vanish.chat.deny = You can only use the admin chat while vanished.
+vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished
 

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -105,10 +105,10 @@ moderation.freeze.freeze = You have frozen {0}
 moderation.freeze.unfreeze = You have unfrozen {0}
 
 # {0} = player name
-moderation.freeze.frozen = You have been frozen by {0}
+moderation.freeze.frozen = You have been frozen
 
 # {0} = player name
-moderation.freeze.unfrozen = You have been unfrozen by {0}
+moderation.freeze.unfrozen = You have been unfrozen
 
 moderation.freeze.itemName = Player Freezer
 

--- a/util/src/main/java/tc/oc/pgm/util/chat/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/chat/Audience.java
@@ -40,6 +40,23 @@ public interface Audience {
   void showBossbar(net.kyori.text.Component message, float progress);
 
   /**
+   * Send a title with desired lengths.
+   *
+   * @param title The upper line
+   * @param subTitle The lower line
+   * @param inTicks Fade in time in ticks
+   * @param stayTicks Length title is displayed
+   * @param outTicks Fade out time in ticks
+   * @return
+   */
+  void showTitle(
+      @Nullable net.kyori.text.Component title,
+      @Nullable net.kyori.text.Component subTitle,
+      int inTicks,
+      int stayTicks,
+      int outTicks);
+
+  /**
    * Play a {@link Sound}, by the raw asset name.
    *
    * @param sound The sound.
@@ -71,6 +88,7 @@ public interface Audience {
   @Deprecated
   void sendHotbarMessage(Component message);
 
+  @Deprecated
   void showTitle(
       @Nullable Component title,
       @Nullable Component subtitle,

--- a/util/src/main/java/tc/oc/pgm/util/chat/MultiAudience.java
+++ b/util/src/main/java/tc/oc/pgm/util/chat/MultiAudience.java
@@ -39,6 +39,16 @@ public interface MultiAudience extends Audience {
     for (Audience a : getAudiences()) a.playSound(sound);
   }
 
+  @Override
+  default void showTitle(
+      @Nullable net.kyori.text.Component title,
+      @Nullable net.kyori.text.Component subTitle,
+      int inTicks,
+      int stayTicks,
+      int outTicks) {
+    for (Audience a : getAudiences()) a.showTitle(title, subTitle, inTicks, stayTicks, outTicks);
+  }
+
   ///////////////////////////////////////////////////////////////
   // METHODS BELOW ARE ALL DEPRECATED AND WILL BE REMOVED SOON //
   ///////////////////////////////////////////////////////////////

--- a/util/src/main/java/tc/oc/pgm/util/chat/PlayerAudience.java
+++ b/util/src/main/java/tc/oc/pgm/util/chat/PlayerAudience.java
@@ -1,12 +1,14 @@
 package tc.oc.pgm.util.chat;
 
 import javax.annotation.Nullable;
-import net.kyori.text.adapter.bukkit.TextAdapter;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.github.paperspigot.Title;
 import tc.oc.pgm.util.component.Component;
 import tc.oc.pgm.util.component.types.PersonalizedText;
 import tc.oc.pgm.util.nms.NMSHacks;
+import tc.oc.pgm.util.text.TextTranslations;
 
 /** An {@link Audience} that represents an online {@link Player}. */
 @FunctionalInterface
@@ -27,12 +29,34 @@ public interface PlayerAudience extends VirtualAudience {
 
   @Override
   default void showHotbar(net.kyori.text.Component message) {
-    TextAdapter.sendActionBar(getAudience(), renderMessage(message));
+    getAudience().sendActionBar(TextTranslations.translateLegacy(message, getAudience()));
   }
 
   @Override
   default void showBossbar(@Nullable net.kyori.text.Component message, float progress) {
     // TODO
+  }
+
+  @Override
+  default void showTitle(
+      @Nullable net.kyori.text.Component title,
+      @Nullable net.kyori.text.Component subTitle,
+      int inTicks,
+      int stayTicks,
+      int outTicks) {
+    Title bukkitTitle =
+        Title.builder()
+            .title(
+                TextComponent.fromLegacyText(
+                    TextTranslations.translateLegacy(title, getAudience())))
+            .subtitle(
+                TextComponent.fromLegacyText(
+                    TextTranslations.translateLegacy(subTitle, getAudience())))
+            .fadeIn(inTicks)
+            .stay(stayTicks)
+            .fadeOut(outTicks)
+            .build();
+    getAudience().sendTitle(bukkitTitle);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/chat/VirtualAudience.java
+++ b/util/src/main/java/tc/oc/pgm/util/chat/VirtualAudience.java
@@ -38,7 +38,8 @@ public interface VirtualAudience extends Audience {
   @Override
   default void sendWarning(net.kyori.text.Component message) {
     sendMessage(
-        TextComponent.of(" \u26a0 ", TextColor.YELLOW).append(message.color(TextColor.RED)));
+        TextComponent.of(" \u26a0 ", TextColor.YELLOW)
+            .append(message.colorIfAbsent(TextColor.RED)));
     playSound(new Sound("note.bass", 1f, 0.75f));
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/chat/VirtualAudience.java
+++ b/util/src/main/java/tc/oc/pgm/util/chat/VirtualAudience.java
@@ -48,6 +48,14 @@ public interface VirtualAudience extends Audience {
   @Override
   default void showBossbar(net.kyori.text.Component message, float progress) {}
 
+  @Override
+  default void showTitle(
+      @Nullable net.kyori.text.Component title,
+      @Nullable net.kyori.text.Component subTitle,
+      int inTicks,
+      int stayTicks,
+      int outTicks) {}
+
   ///////////////////////////////////////////////////////////////
   // METHODS BELOW ARE ALL DEPRECATED AND WILL BE REMOVED SOON //
   ///////////////////////////////////////////////////////////////

--- a/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.text;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,6 +10,9 @@ import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.util.component.ComponentUtils;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.named.Named;
 
@@ -59,5 +63,63 @@ public final class TextFormatter {
   public static Component nameList(
       Collection<? extends Named> names, NameStyle style, TextColor color) {
     return list(Collections2.transform(names, name -> name.getName(style)), color);
+  }
+
+  /**
+   * Appends formatted page number to end of provided text
+   *
+   * @param text Component to apply page to
+   * @param page The current page number
+   * @param pages The total number of pages
+   * @param mainColor The color of the text
+   * @param pageColor The color of the page numbers
+   * @param simple Whether to include 'Page' in wording
+   * @return A message with page information appended.
+   */
+  public static Component paginate(
+      Component text,
+      int page,
+      int pages,
+      TextColor mainColor,
+      TextColor pageColor,
+      boolean simple) {
+    return TextComponent.builder()
+        .append(text)
+        .append(" ")
+        .append("(", mainColor)
+        .append(
+            TranslatableComponent.of(
+                    simple ? "command.simplePageHeader" : "command.pageHeader", TextColor.DARK_AQUA)
+                .args(TextComponent.of(page, pageColor), TextComponent.of(pages, pageColor)))
+        .append(")", mainColor)
+        .build();
+  }
+
+  /**
+   * Formats the provided text with a header that spans the chat window.
+   *
+   * @param sender Who is viewing the list
+   * @param text The text to format
+   * @param lineColor Color of the line
+   * @param width length of the line
+   * @return A formatted header
+   */
+  public static Component horizontalLineHeading(
+      CommandSender sender, Component text, TextColor lineColor, int width) {
+    text = TextComponent.builder().append(" ").append(text).append(" ").build();
+    int textWidth = ComponentUtils.pixelWidth(TextTranslations.translateLegacy(text, sender));
+    int spaceCount =
+        Math.max(0, ((width - textWidth) / 2 + 1) / (ComponentUtils.SPACE_PIXEL_WIDTH + 1));
+    String line = Strings.repeat(" ", spaceCount);
+    return TextComponent.builder()
+        .append(line, lineColor, TextDecoration.STRIKETHROUGH)
+        .append(text)
+        .append(line, lineColor, TextDecoration.STRIKETHROUGH)
+        .build();
+  }
+
+  public static Component horizontalLineHeading(
+      CommandSender sender, Component text, TextColor lineColor) {
+    return horizontalLineHeading(sender, text, lineColor, ComponentUtils.MAX_CHAT_WIDTH);
   }
 }


### PR DESCRIPTION
# May Moderation Fixes 🎉 
This PR contains fixes for several moderation bugs as well as a few small new features.

Overview of changes:
* Frozen players who are kicked, are now automatically unfrozen.
* Add a `-s` flag to `/freeze` command, allowing the freezer to hide their identity. (Vanished will automatically be silent too)
* Rewrote logic for `/reports`, which fixes relogged users having an unformatted name.
* Muted players can now `/msg` staff (fixing a reported bug where sounds play with no message)
* Changed `/setnext` map name color to `GOLD`
* `/setnext -r` will now unset any map that was setnext
* Fix vanished players showing up in `/staff` & `/match`
* Fix vanished players joining before match start and not being forced onto obs
* Fix kick/ban screen missing config
* Fix missing translations (there were a few)
* Moved `PlayerReportEvent` to community package
* Migrate 95% of community module to the new text library
* Vanished players will no longer have their chat setting forcefully set, instead global and team chat will be overridden if a vanished player attempts to use them, and redirected into admin chat.
* Switch /vanish and /freeze to toggle their respective features (removes /unvanish and /unfreeze)


Signed-off-by: applenick <applenick@users.noreply.github.com>