### PR TITLE
Fix blank private messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import javax.annotation.Nullable;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
@@ -23,7 +25,6 @@ import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
 import tc.oc.pgm.util.component.Component;
 import tc.oc.pgm.util.component.ComponentRenderers;
 import tc.oc.pgm.util.component.types.PersonalizedText;
-import tc.oc.pgm.util.component.types.PersonalizedTranslatable;
 
 /**
  * A {@link Goal} that may be 'touched' by players, meaning the player has made some tangible
@@ -210,7 +211,9 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
       }
 
       if (getDeferTouches()) {
-        toucher.sendMessage(new PersonalizedTranslatable("objective.credit.future"));
+        toucher.sendMessage(
+            TranslatableComponent.of("objective.credit.future")
+                .args(TextComponent.of(this.getName())));
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -240,10 +240,8 @@ public class ChatDispatcher implements Listener {
 
   private String formatPrivateMessage(String key, CommandSender viewer) {
     Component action =
-        TranslatableComponent.of(key, TextColor.GRAY)
-            .decoration(TextDecoration.ITALIC, true)
-            .append(TextComponent.of(" " + PREFIX_FORMAT));
-    return TextTranslations.translateLegacy(action, viewer);
+        TranslatableComponent.of(key, TextColor.GRAY).decoration(TextDecoration.ITALIC, true);
+    return TextTranslations.translateLegacy(action, viewer) + " " + PREFIX_FORMAT;
   }
 
   @Command(


### PR DESCRIPTION
# Fix Blank private messages
Resolves #457 

Really quick fix to take care of the blank `/msg` issue. Also included is a bug that was reported where touched objectives did not have their name supplied.  


Signed-off-by: applenick <applenick@users.noreply.github.com>