### PR TITLE
Quick fix for /reports

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -454,7 +454,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       node.registerCommands(vanishManager);
       registerEvents((Listener) vanishManager);
 
-      node.registerCommands(new ReportCommands(datastore));
+      node.registerCommands(new ReportCommands());
       node.registerCommands(new ListCommands(vanishManager));
     }
 


### PR DESCRIPTION
# Quick fix for /reports

I was alerted to some issues that occurred when running `/reports` today on OCC. In order fix this I’ve returned to storing the username of both the reported and reporter in case of viewing when a user is offline. My previous approach of using the datastore to resolve usernames seems a bit overkill for this minor feature. 

 Also minor change, but I adjusted the time component to be a dark green color as previously both offline users and the time were dark aqua. So this way it will differentiate them a bit more.

Signed-off-by: applenick <applenick@users.noreply.github.com>