### PR TITLE
Fix /reports listing incorrect sender

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -255,10 +255,10 @@ public class ReportCommands {
     }
 
     private Component getUsername(UUID uuid, Match match) {
-      MatchPlayer player = match.getPlayer(targetUUID);
+      MatchPlayer player = match.getPlayer(uuid);
       Component name =
           TranslatableComponent.of("misc.unknown", TextColor.AQUA, TextDecoration.ITALIC);
-      if (match.getPlayer(targetUUID) != null) {
+      if (match.getPlayer(uuid) != null) {
         name = player.getName(NameStyle.FANCY);
       } else {
         name =


### PR DESCRIPTION
# Fix /reports listing incorrect sender
Another quick fix for `/reports`, the target located in the hover message was being listed as the sender. 

That’s what I get for testing `/report` on myself haha.

Signed-off-by: applenick <applenick@users.noreply.github.com>