### PR TITLE
Vanish Improvements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -166,10 +166,6 @@ public class VanishManagerImpl implements VanishManager, Listener {
         loginSubdomains.invalidate(player.getId());
         player.setVanished(true);
         addVanished(player);
-
-        player.sendWarning(
-            TranslatableComponent.of("vanish.login.domain", TextColor.GRAY)
-                .args(TextComponent.of(domain, TextColor.AQUA)));
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -17,7 +17,6 @@ import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -160,21 +159,15 @@ public class VanishManagerImpl implements VanishManager, Listener {
         .getBukkit()
         .hasPermission(Permissions.VANISH)) { // Player is not vanished, but has permission to
 
-      // If majority of staff are vanished, auto vanish to keep hidden. Or if player logs in via a
-      // "vanish" subdomain.
+      // Automatic vanish if player logs in via a "vanish" subdomain.
       String domain = loginSubdomains.getIfPresent(player.getId());
-      boolean staff = checkStaffCount();
-      if (staff || domain != null) {
+      if (domain != null) {
         player.setVanished(true);
         addVanished(player);
 
-        if (staff) {
-          player.sendWarning(TranslatableComponent.of("vanish.login.auto", TextColor.GRAY));
-        } else if (domain != null) {
-          player.sendWarning(
-              TranslatableComponent.of("vanish.login.domain", TextColor.GRAY)
-                  .args(TextComponent.of(domain, TextColor.AQUA)));
-        }
+        player.sendWarning(
+            TranslatableComponent.of("vanish.login.domain", TextColor.GRAY)
+                .args(TextComponent.of(domain, TextColor.AQUA)));
       }
     }
   }
@@ -182,17 +175,6 @@ public class VanishManagerImpl implements VanishManager, Listener {
   @EventHandler
   public void checkMatchPlayer(MatchPlayerAddEvent event) {
     event.getPlayer().setVanished(isVanished(event.getPlayer().getId()));
-  }
-
-  private boolean checkStaffCount() {
-    int totalStaff =
-        Bukkit.getOnlinePlayers().stream()
-                .filter(p -> p.hasPermission(Permissions.VANISH))
-                .collect(Collectors.toList())
-                .size()
-            - 1; // Subtract the joining player
-    int vanished = getOnlineVanished().size();
-    return vanished > (totalStaff / 2);
   }
 
   private boolean isVanishSubdomain(String address) {

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -138,11 +138,12 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
   /* Events */
   private final Cache<UUID, String> loginSubdomains =
-      CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.SECONDS).build();
+      CacheBuilder.newBuilder().expireAfterAccess(30, TimeUnit.SECONDS).build();
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPreJoin(PlayerLoginEvent event) {
     Player player = event.getPlayer();
+    loginSubdomains.invalidate(player.getUniqueId());
     if (player.hasPermission(Permissions.VANISH)
         && !isVanished(player.getUniqueId())
         && isVanishSubdomain(event.getHostname())) {
@@ -162,6 +163,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
       // Automatic vanish if player logs in via a "vanish" subdomain.
       String domain = loginSubdomains.getIfPresent(player.getId());
       if (domain != null) {
+        loginSubdomains.invalidate(player.getId());
         player.setVanished(true);
         addVanished(player);
 
@@ -178,7 +180,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
   }
 
   private boolean isVanishSubdomain(String address) {
-    return address.startsWith("vanish"); // TODO Maybe allow config value?
+    return address.startsWith("vanish.");
   }
 
   private void sendHotbarVanish(MatchPlayer player, boolean flashColor) {

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -174,5 +174,3 @@ vanish.deactivate = You are now visible!
 vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished
-
-vanish.login.domain = You logged in with {0} so we auto-vanished you

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -175,5 +175,4 @@ vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished
 
-vanish.login.auto = Majority of staff are vanished. Due to this we've vanished you as well
 vanish.login.domain = You logged in using {0} so we auto-vanished you

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -175,4 +175,4 @@ vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished
 
-vanish.login.domain = You logged in using {0} so we auto-vanished you
+vanish.login.domain = You logged in with {0} so we auto-vanished you

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -175,3 +175,5 @@ vanish.chat.deny = You can only use the admin chat while vanished
 
 vanish.hotbar = You are currently vanished
 
+vanish.login.auto = Majority of staff are vanished. Due to this we've vanished you as well
+vanish.login.domain = You logged in using {0} so we auto-vanished you


### PR DESCRIPTION
# Vanish Subdomain login

This PR adds a requested feature for the `/vanish` command. The detection of players who login using a subdomain starting with `vanish` for example `vanish.oc.tc`. This will allow staff members who wish to forcefully join vanished to do so.

Thanks and if there are any other suggestions for `/vanish` leave your feedback 😄 

Signed-off-by: applenick <applenick@users.noreply.github.com>