### PR TITLE
Small fix to spawner module parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -68,7 +68,7 @@ public class SpawnerModule implements MapModule {
         Duration minDelay = XMLUtils.parseDuration(minDelayAttr, delay);
         Duration maxDelay = XMLUtils.parseDuration(maxDelayAttr, delay);
 
-        if (maxDelay.compareTo(minDelay) <= 0) {
+        if (maxDelay.compareTo(minDelay) <= 0 && minDelayAttr != null && maxDelayAttr != null) {
           throw new InvalidXMLException("Max-delay must be longer than min-delay", element);
         }
 


### PR DESCRIPTION
Sorry for the double PR, should have tested the earlier fix. Makes sure that min and max delay are actually set before checking durations. 