### PR TITLE
Vanish & Map Pools quick fix

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
@@ -41,4 +41,7 @@ public interface MapOrder {
    * @param match The match that just ended
    */
   default void matchEnded(Match match) {}
+
+  /** Reloads the {@link MapOrder} */
+  default void reload() {}
 }

--- a/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -227,25 +227,7 @@ public class AdminCommands {
       perms = Permissions.RELOAD)
   public void pgm() {
     PGM.get().reloadConfig();
-  }
-
-  @Command(
-      aliases = {"reloadpools"},
-      desc = "Reload map pools",
-      perms = Permissions.RELOAD)
-  public void reloadMapPools(Audience viewer) {
-    if (PGM.get().getMapOrder() instanceof MapPoolManager) {
-      int poolCount = ((MapPoolManager) PGM.get().getMapOrder()).reload();
-      viewer.sendWarning(
-          TranslatableComponent.of("command.admin.reloadPools", TextColor.GREEN)
-              .args(TextComponent.of(poolCount, TextColor.GOLD))
-              .append(TextComponent.space())
-              .append(
-                  TranslatableComponent.of(
-                      poolCount != 1 ? "pool.title" : "pool.name", TextColor.GREEN)));
-    } else {
-      viewer.sendWarning(TranslatableComponent.of("command.notEnabled"));
-    }
+    PGM.get().getMapOrder().reload();
   }
 
   private static Map<String, Competitor> getCompetitorMap(CommandSender sender, Match match) {

--- a/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -229,6 +229,25 @@ public class AdminCommands {
     PGM.get().reloadConfig();
   }
 
+  @Command(
+      aliases = {"reloadpools"},
+      desc = "Reload map pools",
+      perms = Permissions.RELOAD)
+  public void reloadMapPools(Audience viewer) {
+    if (PGM.get().getMapOrder() instanceof MapPoolManager) {
+      int poolCount = ((MapPoolManager) PGM.get().getMapOrder()).reload();
+      viewer.sendWarning(
+          TranslatableComponent.of("command.admin.reloadPools", TextColor.GREEN)
+              .args(TextComponent.of(poolCount, TextColor.GOLD))
+              .append(TextComponent.space())
+              .append(
+                  TranslatableComponent.of(
+                      poolCount != 1 ? "pool.title" : "pool.name", TextColor.GREEN)));
+    } else {
+      viewer.sendWarning(TranslatableComponent.of("command.notEnabled"));
+    }
+  }
+
   private static Map<String, Competitor> getCompetitorMap(CommandSender sender, Match match) {
     return match.getCompetitors().stream()
         .map(competitor -> new AbstractMap.SimpleEntry<>(competitor.getName(sender), competitor))

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -111,6 +111,12 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
 
   @Override
   public int compareTo(MapPool o) {
-    return Integer.compare(players, o.players);
+    if (!o.isDynamic()) {
+      return -1;
+    } else if (!isDynamic()) {
+      return 1;
+    } else {
+      return Integer.compare(players, o.players);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -77,9 +77,10 @@ public class MapPoolManager implements MapOrder {
     return mapName;
   }
 
-  public int reload() {
+  @Override
+  public void reload() {
     this.mapPoolFileConfig = YamlConfiguration.loadConfiguration(mapPoolsFile);
-    return loadMapPools();
+    loadMapPools();
   }
 
   private int loadMapPools() {

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -78,3 +78,8 @@ command.message.noReply = Did not find a message to reply to, use {0}
 
 # {0} = player name
 command.message.blocked = {0} is not accepting messages at this time.
+
+# {0} = # number of map pools found
+command.admin.reloadPools = Successfully reloaded {0}
+
+command.notEnabled = Sorry, this command is not enabled

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -78,8 +78,3 @@ command.message.noReply = Did not find a message to reply to, use {0}
 
 # {0} = player name
 command.message.blocked = {0} is not accepting messages at this time.
-
-# {0} = # number of map pools found
-command.admin.reloadPools = Successfully reloaded {0}
-
-command.notEnabled = Sorry, this command is not enabled


### PR DESCRIPTION
# Vanish and Map Pools quick fix
This is another quick PR to fix a few bugs with vanish and map pools.
## Vanish Subdomain fix
There was a reported issue where logging in via a `vanish` subdomain would lead to the server announcing the join message. This fixes that, plus adds a small enhancement where if a player logged in using a `vanish` subdomain they will have their vanish status removed upon quit. (Only if they did not toggle their vanish while online).

## Map Pools fix
So apparently somewhere between my last several PRs, I may have stashed some changes that were crucial to non-dynamic pools working😓. Anyway, this resolves that issue by actually checking when to revert back to dynamic pools. The second bug fixed relates to map activity and fetching the proper dynamic pool after the server restarts.


I don’t believe there’s much else to add here, so unless there is any feedback this should be good to go 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>