### PR TITLE
Remove previous block check on wool proximity

### DIFF
--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -96,9 +95,7 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
   @Override
   protected boolean canBlockUpdateProximity(BlockState oldState, BlockState newState) {
     // If monument proximity metric is closest block, make it only the wool
-    return !hasTouched(getOwner())
-        || (oldState.getType() == Material.AIR
-            && this.getDefinition().isObjectiveWool(newState.getData()));
+    return !hasTouched(getOwner()) || this.getDefinition().isObjectiveWool(newState.getData());
   }
 
   public void handleWoolAcquisition(Player player, ItemStack item) {


### PR DESCRIPTION
Fixes issue described in #479. 

This bug was resolved on 1.12 Project Ares in the same way by [removing the block check](https://github.com/OvercastNetwork/ProjectAres/blob/master/PGM/src/main/java/tc/oc/pgm/wool/MonumentWool.java#L93).

Not sure what the block check was needed for but assume it wasn't needed as it was removed.

Signed-off-by: Pugzy <pugzy@mail.com>