### PR TITLE
Ensure dispensers do not equip observers with armor

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/ArmorType.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorType.java
@@ -23,6 +23,37 @@ public enum ArmorType {
     return inventorySlot >= FIRST_ARMOR_SLOT && inventorySlot < FIRST_ARMOR_SLOT + values().length;
   }
 
+  public static ArmorType getArmorType(ItemStack itemStack) {
+    switch (itemStack.getType()) {
+      case DIAMOND_BOOTS:
+      case IRON_BOOTS:
+      case GOLD_BOOTS:
+      case CHAINMAIL_BOOTS:
+      case LEATHER_BOOTS:
+        return BOOTS;
+      case DIAMOND_LEGGINGS:
+      case IRON_LEGGINGS:
+      case GOLD_LEGGINGS:
+      case CHAINMAIL_LEGGINGS:
+      case LEATHER_LEGGINGS:
+        return LEGGINGS;
+      case DIAMOND_CHESTPLATE:
+      case IRON_CHESTPLATE:
+      case GOLD_CHESTPLATE:
+      case CHAINMAIL_CHESTPLATE:
+      case LEATHER_CHESTPLATE:
+        return CHESTPLATE;
+      case DIAMOND_HELMET:
+      case IRON_HELMET:
+      case GOLD_HELMET:
+      case CHAINMAIL_HELMET:
+      case LEATHER_HELMET:
+        return HELMET;
+      default:
+        return null;
+    }
+  }
+
   public int armorSlot() {
     return this.ordinal();
   }

--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -254,12 +254,12 @@ public class EventFilterMatchModule implements MatchModule, Listener {
     event.setCancelled(true);
     world.playEffect(dispenseLocation, Effect.CLICK1, 1, 16);
 
-    boolean dropItem = false;
+    boolean dropItem = true;
     for (Player player : nearbyParticipatingPlayers) {
       ItemStack currentItem = armorType.getItem(player.getInventory());
       if (currentItem == null || currentItem.getType() == Material.AIR) {
         armorType.setItem(player.getInventory(), item);
-        dropItem = true;
+        dropItem = false;
         break;
       }
     }


### PR DESCRIPTION
Resolves #421 

This will check BlockDispenseEvents and see if they are equipping a player with armor. If an observer is nearby this cancels the event and simulates the dispenser firing. It has to be done this way, since dispensers equipping armor only fire BlockDispenseEvent, and that event doesn't have information on who is getting the armor.

Not sure if EventFilterMatchModule is the best place to put this.