### PR TITLE
Update ProximityMetric.java to allow for "none" as an option, allowing to disable it on a per-map basis

### DIFF
--- a/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
@@ -9,7 +9,8 @@ public class ProximityMetric {
   public static enum Type {
     CLOSEST_PLAYER("closest player"),
     CLOSEST_BLOCK("closest block"),
-    CLOSEST_KILL("closest kill");
+    CLOSEST_KILL("closest kill"),
+    NONE("no proximity")
 
     public final String description;
 

--- a/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
@@ -10,7 +10,7 @@ public class ProximityMetric {
     CLOSEST_PLAYER("closest player"),
     CLOSEST_BLOCK("closest block"),
     CLOSEST_KILL("closest kill"),
-    NONE("no proximity")
+    NONE("no proximity");
 
     public final String description;
 


### PR DESCRIPTION
It allows for none as a proximity metric
(wool-proximity-metric="none", monument-proximity-metric="none" or any other proximity metric in any gamemode) which lets mapmakers disable proximity on a per map basis, allowing for more customability. 

From what Matt has told me, it works because it doesn't have any listener, so proximity never updates for any of the teams, so it remains as "infinity" when you do /proximity.