### PR TITLE
Hide vanished players from server ping and other fixes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -486,7 +486,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     registerEvents(new WorldProblemListener(this));
     registerEvents(new MatchAnnouncer());
     registerEvents(new MotdListener());
-    registerEvents(new ServerPingDataListener(matchManager, mapOrder, getLogger()));
+    registerEvents(new ServerPingDataListener(matchManager, mapOrder, getLogger(), vanishManager));
   }
 
   private class InGameHandler extends Handler {

--- a/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/AdminCommands.java
@@ -162,7 +162,7 @@ public class AdminCommands {
     Component mapName = TextComponent.of(map.getName(), TextColor.GOLD);
     Component successful =
         TranslatableComponent.of("map.setNext", TextColor.GRAY)
-            .args(mapName, UsernameFormatUtils.formatStaffName(sender, match));
+            .args(UsernameFormatUtils.formatStaffName(sender, match), mapName);
     ChatDispatcher.broadcastAdminChatMessage(successful, match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -84,6 +84,15 @@ public class ReportCommands {
     }
 
     MatchPlayer accused = match.getPlayer(player);
+
+    // Don't allow reports of vanished players
+    if (accused.isVanished()) {
+      sender.sendWarning(
+          TextComponent.of(
+              "Could not find player named '" + player.getName() + "'", TextColor.RED));
+      return;
+    }
+
     PlayerReportEvent event = new PlayerReportEvent(sender, accused, reason);
     match.callEvent(event);
 

--- a/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
+++ b/core/src/main/java/tc/oc/pgm/community/commands/ReportCommands.java
@@ -87,6 +87,9 @@ public class ReportCommands {
 
     // Don't allow reports of vanished players
     if (accused.isVanished()) {
+      // Due to Intake not accounting for player locale, this message matches what is sent when no
+      // player is found.
+      // TODO: Please upgrade if command framework uses locale
       sender.sendWarning(
           TextComponent.of(
               "Could not find player named '" + player.getName() + "'", TextColor.RED));

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -168,8 +168,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
       if (domain != null) {
         loginSubdomains.invalidate(player.getId());
         tempVanish.add(player.getId());
-        player.setVanished(true);
-        addVanished(player);
+        setVanished(player, true, true);
       }
     }
   }
@@ -179,8 +178,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
     MatchPlayer player = matchManager.getPlayer(event.getPlayer());
     // If player is vanished & joined via "vanish" subdomain. Remove vanish status on quit
     if (isVanished(player.getId()) && tempVanish.contains(player.getId())) {
-      player.setVanished(false);
-      removeVanished(player);
+      setVanished(player, false, true);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
@@ -164,6 +164,7 @@ public class AntiGriefListener implements Listener {
 
   @EventHandler
   public void giveKit(final ObserverKitApplyEvent event) {
+    if (event.getPlayer().getParty() == null) return;
     if (!event.getPlayer().getParty().isObserving()
         || !event.getPlayer().getBukkit().hasPermission(Permissions.DEFUSE)) return;
 

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -44,9 +44,9 @@ map.info.mapTag.hover = Click to list all {0} maps
 # {0} = map name
 map.nextMap = Next map: {0}
 
-# {0} = map name
-# {1} = player name (who set the map)
-map.setNext = Next map set to {0} by {1}
+# {0} = player name (who set the map)
+# {1} = map name
+map.setNext = {0} set the next map to {1}
 
 map.setNext.confirm = You may not set the next map when a restart is queued. Use -f to override.
 


### PR DESCRIPTION
# Hide vanished players from server ping

This is just a quick PR to address a few minor bugs 🐛

## Fixes:
* Hide vanished players from server ping
* Disallow `/report` being used on vanished players
* Possibly fix issue with vanished players being seen by observers
* Fix a NPE with AntiGriefListener
* Adjust `/setnext` staff broadcast (Resolves #493)

## Screenshot:
![Screen Shot 2020-05-17 at 5 07 33 PM](https://user-images.githubusercontent.com/3377659/82163858-695ad980-9862-11ea-90f7-294364f84a6e.png)


Let me know if there are any issues, but I did test all the changes and everything should be fine 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>