### PR TITLE
Update docs to add "none" as one of the proximity metrics

### DIFF
--- a/docs/modules/objectives/ctf.mdx
+++ b/docs/modules/objectives/ctf.mdx
@@ -444,8 +444,8 @@ Filters can be used to control who can pickup/capture the flag and when.
         <td>
           Metric used to determine proximity to the flag.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>
@@ -471,8 +471,8 @@ Filters can be used to control who can pickup/capture the flag and when.
         <td>
           Metric used to determine proximity to the net.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>

--- a/docs/modules/objectives/ctw.mdx
+++ b/docs/modules/objectives/ctw.mdx
@@ -195,8 +195,8 @@ Players have to retrieve wool blocks from the enemy teams side of the map and th
         <td>
           Metric used to determine proximity to the wool.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>
@@ -222,8 +222,8 @@ Players have to retrieve wool blocks from the enemy teams side of the map and th
         <td>
           Metric used to determine proximity to the monument.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -188,8 +188,8 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
         <td>
           Metric used to determine proximity to the core.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -228,8 +228,8 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           Metric used to determine proximity to the destroyable.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label> or{" "}
-          <label>closest kill</label>
+          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          <label>closest kill</label> or <label>none</label>.
         </td>
         <td>
           <span className="badge badge--primary">Proximity Metric</span>


### PR DESCRIPTION
Due to the new `none` option added here: https://github.com/Electroid/PGM/pull/491/commits/a7f961ae5e2221bf4e9fa32b2eba500f6d334be6